### PR TITLE
Experiment with structured process lifecycle management.

### DIFF
--- a/rpc/internal/proc/proc.go
+++ b/rpc/internal/proc/proc.go
@@ -1,0 +1,103 @@
+// Package proc assits managing the lifecycle of goroutines.
+package proc
+
+import (
+	"context"
+	"sync"
+)
+
+// Spawn a new process.
+//
+// A process can be in one of the following states:
+//
+// - Running
+// - Stopping
+// - Stopped
+//
+// ...starting in the Running state.
+//
+// f is a callback that implements the actual logic of the process. It will be
+// passed a child context of ctx, and a Self. It should:
+//
+// 1. Run until its context is canceled is canceled (or its work is done).
+// 2. invoke BeginShutdown() on the Self that was passed to it, which
+//    transitions the process to the Stopping state.
+// 3. Perform any shutdown logic that is needed.
+// 4. Return. This transitions the process into the Stopped state.
+//
+// Returns a handle, which can be used by clients of the process to interact
+// with its lifecycle.
+func Spawn(ctx context.Context, f func(context.Context, Self)) Handle {
+	ctx, cancel := context.WithCancel(ctx)
+	proc := &proc{
+		cancel: cancel,
+		done:   make(chan struct{}),
+	}
+	handle := Handle{proc}
+	self := Self{proc}
+	go func() {
+		defer func() {
+			self.BeginShutdown()
+			close(proc.done)
+		}()
+		f(ctx, self)
+	}()
+	return handle
+}
+
+// A Handle is used for interacting with a process.
+type Handle struct {
+	proc *proc
+}
+
+// Cancel cancels the process's context.
+func (h Handle) Cancel() {
+	h.proc.cancel()
+}
+
+// Done returns a channel that will be closed when the process transitions
+// to the Stopped state.
+func (h Handle) Done() <-chan struct{} {
+	return h.proc.done
+}
+
+// WithLive attempts to invoke f while keeping the process in the Running state.
+//
+// If the process has already exited the Running state, WithLive returns false
+// without invoking f.
+//
+// If the process is still in the Running state, WithLive invokes the callback,
+// while preventing the process from entering the Stopping state, and then returns
+// true. If the process calls Self.BeginShutdown, it will block until f returns.
+func (h Handle) WithLive(f func()) (ok bool) {
+	h.proc.mu.Lock()
+	defer h.proc.mu.Unlock()
+	if h.proc.shuttingDown {
+		return false
+	}
+	f()
+	return true
+}
+
+// A Self is passed to the process to help manage its own lifecycle.
+type Self struct {
+	proc *proc
+}
+
+// BeginShutdown transitions the process from the Running state to the Stopped
+// state, waiting for any ongoing calls to Handle.WithLive to complete. Once
+// this returns, any calls to WithLive will return false without executing
+// their callback.
+func (s Self) BeginShutdown() {
+	s.proc.mu.Lock()
+	defer s.proc.mu.Unlock()
+	s.proc.shuttingDown = true
+}
+
+// Internal state of the process, shared by Self and Handle.
+type proc struct {
+	mu           sync.Mutex
+	shuttingDown bool
+	cancel       context.CancelFunc
+	done         chan struct{}
+}

--- a/rpc/internal/proc/proc.go
+++ b/rpc/internal/proc/proc.go
@@ -41,10 +41,8 @@ func Spawn[S any](ctx context.Context, state S, f func(context.Context, Self[S])
 	handle := Handle[S]{proc}
 	self := Self[S]{proc}
 	go func() {
-		defer func() {
-			self.BeginShutdown()
-			close(proc.done)
-		}()
+		defer close(proc.done)
+		defer self.BeginShutdown()
 		f(ctx, self)
 	}()
 	return handle

--- a/rpc/sender.go
+++ b/rpc/sender.go
@@ -1,0 +1,96 @@
+package rpc
+
+import (
+	"context"
+
+	"capnproto.org/go/capnp/v3"
+	"capnproto.org/go/capnp/v3/internal/mpsc"
+	"capnproto.org/go/capnp/v3/rpc/internal/proc"
+	rpccp "capnproto.org/go/capnp/v3/std/capnp/rpc"
+)
+
+type sender struct {
+	proc  proc.Handle
+	trans Transport
+	tx    *mpsc.Tx[sendJob]
+}
+
+func spawnSender(ctx context.Context, trans Transport) *sender {
+	q := mpsc.New[sendJob]()
+	rx := &q.Rx
+	return &sender{
+		tx:    &q.Tx,
+		trans: trans,
+		proc: proc.Spawn(ctx, func(ctx context.Context, self proc.Self) {
+			for {
+				job, err := rx.Recv(ctx)
+				if err != nil {
+					break
+				}
+				job.onSent(job.send())
+			}
+			self.BeginShutdown()
+			for {
+				job, ok := rx.TryRecv()
+				if !ok {
+					break
+				}
+				job.onSent(ErrConnClosed)
+			}
+		}),
+	}
+
+}
+
+// Stop the sender. Returns
+func (s *sender) Stop() {
+	s.proc.Cancel()
+}
+
+func (s *sender) Done() <-chan struct{} {
+	return s.proc.Done()
+}
+
+type sendJob struct {
+	send   func() error
+	onSent func(error)
+}
+
+type sendArgs struct {
+	Msg     rpccp.Message
+	Send    func(onSent func(err error))
+	Release capnp.ReleaseFunc
+}
+
+func (s *sender) StartMessage(ctx context.Context) (sendArgs, error) {
+	var (
+		msg     rpccp.Message
+		send    func() error
+		release capnp.ReleaseFunc
+		err     error
+	)
+	ok := s.proc.WithLive(func() {
+		msg, send, release, err = s.trans.NewMessage(ctx)
+	})
+	if !ok {
+		return sendArgs{}, ErrConnClosed
+	}
+	if err != nil {
+		return sendArgs{}, err
+	}
+	return sendArgs{
+		Msg:     msg,
+		Release: release,
+		Send: func(onSent func(error)) {
+			ok := s.proc.WithLive(func() {
+				s.tx.Send(sendJob{
+					send:   send,
+					onSent: onSent,
+				})
+			})
+			if !ok {
+				onSent(ErrConnClosed)
+			}
+		},
+	}, nil
+}


### PR DESCRIPTION
@lthibault, I started playing with my own ideas about how to clean up process lifecycle management. I'm curious to your thoughts, particularly regarding.

- Whether you think the proc package is The Right Abstraction, and whether it will actually help with the rest of the shutdown logic.
- If not, what does `goprocess` give us that this doesn't?

Part of this is my attempt to understand the problem space.

---

This patch introduces a `proc` package under internal, with an
abstraction I think will be useful in cleaning up the shutdown logic.

It also includes a rework of the send goroutine (in sender.go) that
reflects how I *want* this to work (notably, the logic for drainQueue
runs in the send gorotuine itself), and how the proc package can be used
to help with that. The new sender is dead code; I intend this as a
starting point for discussion.