### PR TITLE
WIP: avoid deadlocks wrt. embargo

### DIFF
--- a/answer.go
+++ b/answer.go
@@ -270,12 +270,12 @@ func ErrorAnswer(m Method, e error) *Answer {
 	return &p.ans
 }
 
-// ImmediateAnswer returns an Answer that accesses s.
-func ImmediateAnswer(m Method, s Struct) *Answer {
+// ImmediateAnswer returns an Answer that accesses ptr.
+func ImmediateAnswer(m Method, ptr Ptr) *Answer {
 	p := &Promise{
 		method:   m,
 		resolved: closedSignal,
-		result:   s.ToPtr(),
+		result:   ptr,
 	}
 	p.ans.f.promise = p
 	p.ans.metadata = *NewMetadata()

--- a/answerqueue.go
+++ b/answerqueue.go
@@ -159,7 +159,8 @@ func (qc queueCaller) PipelineSend(ctx context.Context, transform []PipelineOp, 
 	}
 	if s.PlaceArgs != nil {
 		var err error
-		r.Args, err = newBlankStruct(s.ArgsSize)
+		_, seg := NewMultiSegmentMessage(nil)
+		r.Args, err = NewRootStruct(seg, s.ArgsSize)
 		if err != nil {
 			return ErrorAnswer(s.Method, err), func() {}
 		}
@@ -199,7 +200,8 @@ func (sr *StructReturner) AllocResults(sz ObjectSize) (Struct, error) {
 		return Struct{}, errors.New("StructReturner: multiple calls to AllocResults")
 	}
 	sr.alloced = true
-	s, err := newBlankStruct(sz)
+	_, seg := NewMultiSegmentMessage(nil)
+	s, err := NewRootStruct(seg, sz)
 	if err != nil {
 		return Struct{}, exc.WrapError("alloc results", err)
 	}
@@ -295,17 +297,4 @@ func (sr *StructReturner) Answer(m Method, pcall PipelineCaller) (*Answer, Relea
 			msg.Reset(nil)
 		}
 	}
-}
-
-// TODO(cleanup): this is copypasta from the server package.
-func newBlankStruct(sz ObjectSize) (Struct, error) {
-	_, seg, err := NewMessage(MultiSegment(nil))
-	if err != nil {
-		return Struct{}, err
-	}
-	st, err := NewRootStruct(seg, sz)
-	if err != nil {
-		return Struct{}, err
-	}
-	return st, nil
 }

--- a/answerqueue.go
+++ b/answerqueue.go
@@ -56,9 +56,9 @@ func NewAnswerQueue(m Method) *AnswerQueue {
 }
 
 // Fulfill empties the queue, delivering the method calls on the given
-// struct.  After fulfill returns, pipeline calls will be immediately
+// pointer.  After fulfill returns, pipeline calls will be immediately
 // delivered instead of being queued.
-func (aq *AnswerQueue) Fulfill(s Struct) {
+func (aq *AnswerQueue) Fulfill(ptr Ptr) {
 	// Enter draining state.
 	aq.mu.Lock()
 	q := aq.q
@@ -69,7 +69,7 @@ func (aq *AnswerQueue) Fulfill(s Struct) {
 	for i := range aq.bases {
 		aq.bases[i].ready = ready
 	}
-	aq.bases[0].recv = ImmediateAnswer(aq.method, s).PipelineRecv
+	aq.bases[0].recv = ImmediateAnswer(aq.method, ptr).PipelineRecv
 	close(aq.draining)
 	aq.mu.Unlock()
 
@@ -272,7 +272,7 @@ func (sr *StructReturner) Answer(m Method, pcall PipelineCaller) (*Answer, Relea
 		if sr.err != nil {
 			return ErrorAnswer(m, sr.err), func() {}
 		}
-		return ImmediateAnswer(m, sr.result), func() {
+		return ImmediateAnswer(m, sr.result.ToPtr()), func() {
 			sr.mu.Lock()
 			msg := sr.result.Message()
 			sr.result = Struct{}

--- a/capability_test.go
+++ b/capability_test.go
@@ -270,7 +270,7 @@ type dummyHook struct {
 
 func (dh *dummyHook) Send(_ context.Context, s Send) (*Answer, ReleaseFunc) {
 	dh.calls++
-	return ImmediateAnswer(s.Method, newEmptyStruct()), func() {}
+	return ImmediateAnswer(s.Method, newEmptyStruct().ToPtr()), func() {}
 }
 
 func (dh *dummyHook) Recv(_ context.Context, r Recv) PipelineCaller {

--- a/rpc/export.go
+++ b/rpc/export.go
@@ -203,9 +203,8 @@ func (c *lockedConn) fillPayloadCapTable(payload rpccp.Payload) (map[exportID]ui
 type embargoID uint32
 
 type embargo struct {
-	c      capnp.Client
-	p      *capnp.ClientPromise
-	lifted chan struct{}
+	result capnp.Ptr
+	q      *capnp.AnswerQueue
 }
 
 // embargo creates a new embargoed client, stealing the reference.
@@ -213,18 +212,13 @@ type embargo struct {
 // The caller must be holding onto c.mu.
 func (c *lockedConn) embargo(client capnp.Client) (embargoID, capnp.Client) {
 	id := embargoID(c.lk.embargoID.next())
-	e := &embargo{
-		c:      client,
-		lifted: make(chan struct{}),
-	}
+	e := newEmbargo(client)
 	if int64(id) == int64(len(c.lk.embargoes)) {
 		c.lk.embargoes = append(c.lk.embargoes, e)
 	} else {
 		c.lk.embargoes[id] = e
 	}
-	var c2 capnp.Client
-	c2, c.lk.embargoes[id].p = capnp.NewPromisedClient(c.lk.embargoes[id])
-	return id, c2
+	return id, capnp.NewClient(e)
 }
 
 // findEmbargo returns the embargo entry with the given ID or nil if
@@ -236,29 +230,28 @@ func (c *lockedConn) findEmbargo(id embargoID) *embargo {
 	return c.lk.embargoes[id] // might be nil
 }
 
+func newEmbargo(client capnp.Client) *embargo {
+	msg, seg := capnp.NewSingleSegmentMessage(nil)
+	capID := msg.AddCap(client)
+	iface := capnp.NewInterface(seg, capID)
+	return &embargo{
+		result: iface.ToPtr(),
+		q:      capnp.NewAnswerQueue(capnp.Method{}),
+	}
+}
+
 // lift disembargoes the client.  It must be called only once.
 func (e *embargo) lift() {
-	close(e.lifted)
-	e.p.Fulfill(e.c)
+	e.q.Fulfill(e.result)
 }
 
 func (e *embargo) Send(ctx context.Context, s capnp.Send) (*capnp.Answer, capnp.ReleaseFunc) {
-	select {
-	case <-e.lifted:
-		return e.c.SendCall(ctx, s)
-	case <-ctx.Done():
-		return capnp.ErrorAnswer(s.Method, ctx.Err()), func() {}
-	}
+	return e.q.PipelineSend(ctx, nil, s)
 }
 
 func (e *embargo) Recv(ctx context.Context, r capnp.Recv) capnp.PipelineCaller {
-	select {
-	case <-e.lifted:
-		return e.c.RecvCall(ctx, r)
-	case <-ctx.Done():
-		r.Reject(ctx.Err())
-		return nil
-	}
+
+	return e.q.PipelineRecv(ctx, nil, r)
 }
 
 func (e *embargo) Brand() capnp.Brand {
@@ -266,7 +259,8 @@ func (e *embargo) Brand() capnp.Brand {
 }
 
 func (e *embargo) Shutdown() {
-	e.c.Release()
+	e.result.Interface().Client().Release()
+	// FIXME: what to do with contents of queue?
 }
 
 // senderLoopback holds the salient information for a sender-loopback

--- a/rpc/export.go
+++ b/rpc/export.go
@@ -208,7 +208,10 @@ type embargo struct {
 }
 
 func (e embargo) String() string {
-	return "embargo{c: " + e.c.String() + ", 0x" + str.PtrToHex(e.p) + "}"
+	return "embargo{client: " +
+		e.client().String() +
+		", q: 0x" + str.PtrToHex(e.q) +
+		"}"
 }
 
 // embargo creates a new embargoed client, stealing the reference.
@@ -262,8 +265,12 @@ func (e *embargo) Brand() capnp.Brand {
 	return capnp.Brand{}
 }
 
+func (e *embargo) client() capnp.Client {
+	return e.result.Interface().Client()
+}
+
 func (e *embargo) Shutdown() {
-	e.result.Interface().Client().Release()
+	e.client().Release()
 }
 
 // senderLoopback holds the salient information for a sender-loopback

--- a/rpc/export.go
+++ b/rpc/export.go
@@ -260,7 +260,6 @@ func (e *embargo) Brand() capnp.Brand {
 
 func (e *embargo) Shutdown() {
 	e.result.Interface().Client().Release()
-	// FIXME: what to do with contents of queue?
 }
 
 // senderLoopback holds the salient information for a sender-loopback

--- a/server/server.go
+++ b/server/server.go
@@ -268,25 +268,14 @@ func sendArgsToStruct(s capnp.Send) (capnp.Struct, error) {
 	if s.PlaceArgs == nil {
 		return capnp.Struct{}, nil
 	}
-	st, err := newBlankStruct(s.ArgsSize)
+	_, seg := capnp.NewMultiSegmentMessage(nil)
+	st, err := capnp.NewRootStruct(seg, s.ArgsSize)
 	if err != nil {
 		return capnp.Struct{}, err
 	}
 	if err := s.PlaceArgs(st); err != nil {
 		st.Message().Reset(nil)
 		return capnp.Struct{}, exc.WrapError("place args", err)
-	}
-	return st, nil
-}
-
-func newBlankStruct(sz capnp.ObjectSize) (capnp.Struct, error) {
-	_, seg, err := capnp.NewMessage(capnp.MultiSegment(nil))
-	if err != nil {
-		return capnp.Struct{}, err
-	}
-	st, err := capnp.NewRootStruct(seg, sz)
-	if err != nil {
-		return capnp.Struct{}, err
 	}
 	return st, nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -214,7 +214,7 @@ func (srv *Server) handleCall(ctx context.Context, c *Call) {
 	c.recv.ReleaseArgs()
 	c.recv.Returner.PrepareReturn(err)
 	if err == nil {
-		c.aq.Fulfill(c.results)
+		c.aq.Fulfill(c.results.ToPtr())
 	} else {
 		c.aq.Reject(err)
 	}


### PR DESCRIPTION
This patch:

- Moves the answerQueue (and structReturner) types from the server package into the main package, and exports them.
- Reworks the implementation of embargo in the rpc package to use answerQueue; this makes the queue unbounded instead of having Send & Recv just block, which should head off some potential deadlocks which right now I think require multiple connections to trigger.

Marking this WIP because there are a few bits that are still a little dodgy, both stylistically and in terms of correctness. But the tests pass.