### PR TITLE
Support writing to reset messages.

### DIFF
--- a/message.go
+++ b/message.go
@@ -558,7 +558,7 @@ func MultiSegment(b [][]byte) *MultiSegmentArena {
 func (msa *MultiSegmentArena) Release() {
 	for i, v := range *msa {
 		// Clear the memory, so there's no junk in here for the next use:
-		for j, _ := range v {
+		for j := range v {
 			v[j] = 0
 		}
 


### PR DESCRIPTION
Note:  this changes the call signature of `Message.Reset`, but in a manner that is compatible with current use.

Also, it seems like this change allows us to get rid of `roSingleSegment`?