### PR TITLE
Remove capnperr annotator (unused).

### DIFF
--- a/error.go
+++ b/error.go
@@ -4,10 +4,6 @@ import (
 	"capnproto.org/go/capnp/v3/exc"
 )
 
-var (
-	capnperr = exc.Annotator("capnp")
-)
-
 // TODO(someday):  progressively remove exported functions and instead
 //                 rely on package 'exc'.
 


### PR DESCRIPTION
Remove unused type from `error.go`.  No functional changes.