### PR TITLE
Stub out places where we need to add logic for 3PH

### DIFF
--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -594,19 +594,6 @@ func (c *Conn) receive() error {
 			return err
 		}
 
-		sendUnimplemented := func(err error) {
-			c.er.ReportError(err)
-			c.withLocked(func(c *lockedConn) {
-				c.sendMessage(ctx, func(m rpccp.Message) error {
-					defer release()
-					if err := m.SetUnimplemented(recv); err != nil {
-						return rpcerr.Annotate(err, "send unimplemented")
-					}
-					return nil
-				}, nil)
-			})
-		}
-
 		switch recv.Which() {
 		case rpccp.Message_Which_unimplemented:
 			// no-op for now to avoid feedback loop
@@ -704,20 +691,22 @@ func (c *Conn) receive() error {
 				return err
 			}
 		// TODO: handle resolve.
-		case rpccp.Message_Which_accept:
-			if c.network == nil {
-				sendUnimplemented(errors.New("Accept from remote not supported: connection has no associated network"))
-				continue
+		case rpccp.Message_Which_accept, rpccp.Message_Which_provide:
+			if c.network != nil {
+				panic("TODO: 3PH")
 			}
-			panic("TODO: 3PH")
-		case rpccp.Message_Which_provide:
-			if c.network == nil {
-				sendUnimplemented(errors.New("Provide from remote not supported: connection has no associated network"))
-				continue
-			}
-			panic("TODO: 3PH")
+			fallthrough
 		default:
-			sendUnimplemented(errors.New("unknown message type " + recv.Which().String() + " from remote"))
+			c.er.ReportError(errors.New("unknown message type " + recv.Which().String() + " from remote"))
+			c.withLocked(func(c *lockedConn) {
+				c.sendMessage(ctx, func(m rpccp.Message) error {
+					defer release()
+					if err := m.SetUnimplemented(recv); err != nil {
+						return rpcerr.Annotate(err, "send unimplemented")
+					}
+					return nil
+				}, nil)
+			})
 		}
 	}
 }


### PR DESCRIPTION
Should have no functional change, except for:

- The exact text of some errors
- Some codepaths will panic if a network is provided in rpc.Options; should not affect any existing applications, obviously.

This patch just stubs out the places where logic will need to be modified to support 3PH; I think it will be helpful to have these enumerated up front. I took some pointers from the Haskell implementation on this, since I added similar markers as comments when I was writing that in the first place.