### PR TITLE
Drop support for go 1.18

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.18', '1.19', '1.20' ]
+        go: [ '1.19', '1.20' ]
         arch: [ 'amd64', '386' ]
     name: Go ${{ matrix.go }} GOARCH=${{ matrix.arch }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module capnproto.org/go/capnp/v3
 
-go 1.18
+go 1.19
 
 require (
 	github.com/kylelemons/godebug v1.1.0


### PR DESCRIPTION
As per [discussion](https://matrix.to/#/!pLcnVUHHRZrUPscloW:matrix.org/$TpVPAHo7y3o-MKbvQurPDXz3iiLGNhkTf0XKAaVPfWA?via=matrix.org) on Matrix:  drop support for Go 1.18. 