### PR TITLE
Clean up rpc.Conn.receive

### DIFF
--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -627,8 +627,7 @@ func (c *Conn) receive(ctx context.Context, incoming <-chan transport.IncomingMe
 			}
 		}
 
-		// incoming channel was closed; graceful exit.
-		return ctx.Err()
+		return nil
 	})
 }
 

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -1754,7 +1754,7 @@ func (c *lockedConn) sendMessage(ctx context.Context, build func(rpccp.Message) 
 // time RecvMessage() returns an error, its results will still be sent on the
 // channel.
 func (c *Conn) reader(ctx context.Context, in chan<- transport.IncomingMessage) func() error {
-	return func() error {
+	return c.backgroundTask(func() error {
 		defer close(in)
 
 		ctx, cancel := context.WithCancel(ctx)
@@ -1805,7 +1805,7 @@ func (c *Conn) reader(ctx context.Context, in chan<- transport.IncomingMessage) 
 		default:
 			return ctx.Err()
 		}
-	}
+	})
 }
 
 type asyncSend struct {


### PR DESCRIPTION
This is a refactor of `rpc.Conn` for readability.   There are no functional changes.

Clean-up is concentrated in two places:

1. The `switch` statement in `Conn.receive` is tidied up by having each `case` call out to a dedicated "handler" method.
2. <del>The `reader` thread is moved into its own task, allowing it to trigger task shutdown on its own.  This in turn lets us implement `receiver` as a simple `range` loop over a channel.</del>

A follow-up effort will focus on abstracting tasks & connection lifecycle.