### PR TITLE
Remove unused method rpc.Conn.getAnswerQuestion.

### DIFF
--- a/rpc/question.go
+++ b/rpc/question.go
@@ -67,17 +67,7 @@ func (c *lockedConn) newQuestion(method capnp.Method) *question {
 	return q
 }
 
-func (c *Conn) getAnswerQuestion(ans *capnp.Answer) (*question, bool) {
-	// Note: lockedConn.getAnswerQuestion doesn't actually do anything with the
-	// locked data, but we end up needing to call this method on both types so
-	// we define it there as well.
-	return (*lockedConn)(c).getAnswerQuestion(ans)
-}
-
 func (c *lockedConn) getAnswerQuestion(ans *capnp.Answer) (*question, bool) {
-	// Note: make sure to update Conn.getAnswerQuestion if this ever changes
-	// to access c.lk for some strange reason.
-
 	m := ans.Metadata()
 	m.Lock()
 	defer m.Unlock()


### PR DESCRIPTION
This isn't used anywhere, despite what the comment says, so it seems like we could delete it.