### PR TITLE
Don't export ClientPromise, use an interface instead.

### DIFF
--- a/answer.go
+++ b/answer.go
@@ -76,7 +76,7 @@ type Promise struct {
 
 type clientAndPromise struct {
 	client  Client
-	promise *ClientPromise
+	promise *clientPromise
 }
 
 // NewPromise creates a new unresolved promise.  The PipelineCaller will
@@ -148,7 +148,7 @@ func (p *Promise) Reject(e error) {
 // If e != nil, then this is equivalent to p.Reject(e).
 // Otherwise, it is equivalent to p.Fulfill(r).
 func (p *Promise) Resolve(r Ptr, e error) {
-	var shutdownPromises []*ClientPromise
+	var shutdownPromises []*clientPromise
 	syncutil.With(&p.mu, func() {
 		if e != nil {
 			p.requireUnresolved("Reject")
@@ -466,7 +466,7 @@ func (f *Future) Client() Client {
 		if cp := p.clients[cpath]; cp != nil {
 			return cp.client
 		}
-		c, pr := NewPromisedClient(PipelineClient{
+		c, pr := newPromisedClient(PipelineClient{
 			p:         p,
 			transform: ft,
 		})

--- a/capability.go
+++ b/capability.go
@@ -198,7 +198,7 @@ func NewClient(hook ClientHook) Client {
 //
 // Typically the RPC system will create a client for the application.
 // Most applications will not need to use this directly.
-func NewPromisedClient(hook ClientHook) (Client, Fulfiller[Client]) {
+func NewPromisedClient(hook ClientHook) (Client, Resolver[Client]) {
 	return newPromisedClient(hook)
 }
 

--- a/capability.go
+++ b/capability.go
@@ -198,7 +198,13 @@ func NewClient(hook ClientHook) Client {
 //
 // Typically the RPC system will create a client for the application.
 // Most applications will not need to use this directly.
-func NewPromisedClient(hook ClientHook) (Client, *ClientPromise) {
+func NewPromisedClient(hook ClientHook) (Client, Fulfiller[Client]) {
+	return newPromisedClient(hook)
+}
+
+// newPromisedClient is the same as NewPromisedClient, but the return
+// value exposes the concrete type of the fulfiller.
+func newPromisedClient(hook ClientHook) (Client, *clientPromise) {
 	if hook == nil {
 		panic("NewPromisedClient(nil)")
 	}
@@ -211,7 +217,7 @@ func NewPromisedClient(hook ClientHook) (Client, *ClientPromise) {
 	}
 	c := Client{client: &client{h: h}}
 	c.setupLeakReporting(2)
-	return c, &ClientPromise{h: h}
+	return c, &clientPromise{h: h}
 }
 
 // startCall holds onto a hook to prevent it from shutting down until
@@ -727,11 +733,11 @@ func finalizeClient(c *client) {
 }
 
 // A ClientPromise resolves the identity of a client created by NewPromisedClient.
-type ClientPromise struct {
+type clientPromise struct {
 	h *clientHook
 }
 
-func (cp *ClientPromise) Reject(err error) {
+func (cp *clientPromise) Reject(err error) {
 	cp.Fulfill(ErrorClient(err))
 }
 
@@ -741,7 +747,7 @@ func (cp *ClientPromise) Reject(err error) {
 // NewPromisedClient will be shut down after Fulfill returns, but the
 // hook may have been shut down earlier if the client ran out of
 // references.
-func (cp *ClientPromise) Fulfill(c Client) {
+func (cp *clientPromise) Fulfill(c Client) {
 	cp.fulfill(c)
 	cp.shutdown()
 }
@@ -749,14 +755,14 @@ func (cp *ClientPromise) Fulfill(c Client) {
 // shutdown waits for all outstanding calls on the hook to complete and
 // references to be dropped, and then shuts down the hook. The caller
 // must have previously invoked cp.fulfill().
-func (cp *ClientPromise) shutdown() {
+func (cp *clientPromise) shutdown() {
 	<-cp.h.done
 	cp.h.Shutdown()
 }
 
 // fulfill is like Fulfill, except that it does not wait for outsanding calls
 // to return answers or shut down the underlying hook.
-func (cp *ClientPromise) fulfill(c Client) {
+func (cp *clientPromise) fulfill(c Client) {
 	// Obtain next client hook.
 	var rh *clientHook
 	if (c != Client{}) {

--- a/fulfiller.go
+++ b/fulfiller.go
@@ -1,7 +1,7 @@
 package capnp
 
-// A Fulfiller supplies a value for a pending promise.
-type Fulfiller[T any] interface {
+// A Resolver supplies a value for a pending promise.
+type Resolver[T any] interface {
 	// Fulfill supplies the value for the corresponding
 	// Promise
 	Fulfill(T)

--- a/fulfiller.go
+++ b/fulfiller.go
@@ -1,0 +1,12 @@
+package capnp
+
+// A Fulfiller supplies a value for a pending promise.
+type Fulfiller[T any] interface {
+	// Fulfill supplies the value for the corresponding
+	// Promise
+	Fulfill(T)
+
+	// Reject rejects the corresponding promise, with
+	// the specified error.
+	Reject(error)
+}

--- a/rpc/question.go
+++ b/rpc/question.go
@@ -15,7 +15,7 @@ type question struct {
 	c  *Conn
 	id questionID
 
-	bootstrapPromise capnp.Fulfiller[capnp.Client]
+	bootstrapPromise capnp.Resolver[capnp.Client]
 
 	p       *capnp.Promise
 	release capnp.ReleaseFunc // written before resolving p

--- a/rpc/question.go
+++ b/rpc/question.go
@@ -15,7 +15,7 @@ type question struct {
 	c  *Conn
 	id questionID
 
-	bootstrapPromise *capnp.ClientPromise
+	bootstrapPromise capnp.Fulfiller[capnp.Client]
 
 	p       *capnp.Promise
 	release capnp.ReleaseFunc // written before resolving p


### PR DESCRIPTION
I have at least one other type of fulfiller planned, and these are its only exported methods anyway.

In particular, I'm working on a `ClientHook` that wraps `AnswerQueue`, but I need to hook into the resolution logic to flush the queue.