### PR TITLE
Add NewLocalPromise() api

### DIFF
--- a/answer.go
+++ b/answer.go
@@ -76,7 +76,7 @@ type Promise struct {
 
 type clientAndPromise struct {
 	client  Client
-	promise *ClientPromise
+	promise *clientPromise
 }
 
 // NewPromise creates a new unresolved promise.  The PipelineCaller will
@@ -148,7 +148,7 @@ func (p *Promise) Reject(e error) {
 // If e != nil, then this is equivalent to p.Reject(e).
 // Otherwise, it is equivalent to p.Fulfill(r).
 func (p *Promise) Resolve(r Ptr, e error) {
-	var shutdownPromises []*ClientPromise
+	var shutdownPromises []*clientPromise
 	syncutil.With(&p.mu, func() {
 		if e != nil {
 			p.requireUnresolved("Reject")
@@ -466,7 +466,7 @@ func (f *Future) Client() Client {
 		if cp := p.clients[cpath]; cp != nil {
 			return cp.client
 		}
-		c, pr := NewPromisedClient(PipelineClient{
+		c, pr := newPromisedClient(PipelineClient{
 			p:         p,
 			transform: ft,
 		})

--- a/capability.go
+++ b/capability.go
@@ -198,7 +198,7 @@ func NewClient(hook ClientHook) Client {
 //
 // Typically the RPC system will create a client for the application.
 // Most applications will not need to use this directly.
-func NewPromisedClient(hook ClientHook) (Client, Fulfiller[Client]) {
+func NewPromisedClient(hook ClientHook) (Client, Resolver[Client]) {
 	return newPromisedClient(hook)
 }
 

--- a/capability.go
+++ b/capability.go
@@ -198,7 +198,13 @@ func NewClient(hook ClientHook) Client {
 //
 // Typically the RPC system will create a client for the application.
 // Most applications will not need to use this directly.
-func NewPromisedClient(hook ClientHook) (Client, *ClientPromise) {
+func NewPromisedClient(hook ClientHook) (Client, Fulfiller[Client]) {
+	return newPromisedClient(hook)
+}
+
+// newPromisedClient is the same as NewPromisedClient, but the return
+// value exposes the concrete type of the fulfiller.
+func newPromisedClient(hook ClientHook) (Client, *clientPromise) {
 	if hook == nil {
 		panic("NewPromisedClient(nil)")
 	}
@@ -211,7 +217,7 @@ func NewPromisedClient(hook ClientHook) (Client, *ClientPromise) {
 	}
 	c := Client{client: &client{h: h}}
 	c.setupLeakReporting(2)
-	return c, &ClientPromise{h: h}
+	return c, &clientPromise{h: h}
 }
 
 // startCall holds onto a hook to prevent it from shutting down until
@@ -727,11 +733,11 @@ func finalizeClient(c *client) {
 }
 
 // A ClientPromise resolves the identity of a client created by NewPromisedClient.
-type ClientPromise struct {
+type clientPromise struct {
 	h *clientHook
 }
 
-func (cp *ClientPromise) Reject(err error) {
+func (cp *clientPromise) Reject(err error) {
 	cp.Fulfill(ErrorClient(err))
 }
 
@@ -741,7 +747,7 @@ func (cp *ClientPromise) Reject(err error) {
 // NewPromisedClient will be shut down after Fulfill returns, but the
 // hook may have been shut down earlier if the client ran out of
 // references.
-func (cp *ClientPromise) Fulfill(c Client) {
+func (cp *clientPromise) Fulfill(c Client) {
 	cp.fulfill(c)
 	cp.shutdown()
 }
@@ -749,14 +755,14 @@ func (cp *ClientPromise) Fulfill(c Client) {
 // shutdown waits for all outstanding calls on the hook to complete and
 // references to be dropped, and then shuts down the hook. The caller
 // must have previously invoked cp.fulfill().
-func (cp *ClientPromise) shutdown() {
+func (cp *clientPromise) shutdown() {
 	<-cp.h.done
 	cp.h.Shutdown()
 }
 
 // fulfill is like Fulfill, except that it does not wait for outsanding calls
 // to return answers or shut down the underlying hook.
-func (cp *ClientPromise) fulfill(c Client) {
+func (cp *clientPromise) fulfill(c Client) {
 	// Obtain next client hook.
 	var rh *clientHook
 	if (c != Client{}) {

--- a/fulfiller.go
+++ b/fulfiller.go
@@ -1,7 +1,7 @@
 package capnp
 
-// A Fulfiller supplies a value for a pending promise.
-type Fulfiller[T any] interface {
+// A Resolver supplies a value for a pending promise.
+type Resolver[T any] interface {
 	// Fulfill supplies the value for the corresponding
 	// Promise
 	Fulfill(T)

--- a/fulfiller.go
+++ b/fulfiller.go
@@ -1,0 +1,12 @@
+package capnp
+
+// A Fulfiller supplies a value for a pending promise.
+type Fulfiller[T any] interface {
+	// Fulfill supplies the value for the corresponding
+	// Promise
+	Fulfill(T)
+
+	// Reject rejects the corresponding promise, with
+	// the specified error.
+	Reject(error)
+}

--- a/localpromise.go
+++ b/localpromise.go
@@ -1,0 +1,40 @@
+package capnp
+
+import (
+	"context"
+)
+
+// ClientHook for a promise that will be resolved to some other capability
+// at some point. Buffers calls in a queue until the promsie is fulfilled,
+// then forwards them.
+type localPromise struct {
+	aq *AnswerQueue
+}
+
+func newLocalPromise() *localPromise {
+	return &localPromise{NewAnswerQueue(Method{})}
+}
+
+func (lp localPromise) Send(ctx context.Context, s Send) (*Answer, ReleaseFunc) {
+	return lp.aq.PipelineSend(ctx, nil, s)
+}
+
+func (lp localPromise) Recv(ctx context.Context, r Recv) PipelineCaller {
+	return lp.aq.PipelineRecv(ctx, nil, r)
+}
+
+func (lp localPromise) Brand() Brand {
+	return Brand{}
+}
+
+func (lp localPromise) Shutdown() {}
+
+func (lp localPromise) Fulfill(c Client) {
+	msg, seg := NewSingleSegmentMessage(nil)
+	capID := msg.AddCap(c)
+	lp.aq.Fulfill(NewInterface(seg, capID).ToPtr())
+}
+
+func (lp localPromise) Reject(err error) {
+	lp.aq.Reject(err)
+}

--- a/localpromise.go
+++ b/localpromise.go
@@ -23,7 +23,7 @@ func NewLocalPromise[C ~ClientKind]() (C, Fulfiller[C]) {
 }
 
 func newLocalPromise() localPromise {
-	return localPromise{NewAnswerQueue(Method{})}
+	return localPromise{aq: NewAnswerQueue(Method{})}
 }
 
 func (lp localPromise) Send(ctx context.Context, s Send) (*Answer, ReleaseFunc) {

--- a/localpromise.go
+++ b/localpromise.go
@@ -13,12 +13,12 @@ type localPromise struct {
 
 // NewLocalPromise returns a client that will eventually resolve to a capability,
 // supplied via the fulfiller.
-func NewLocalPromise[C ~ClientKind]() (C, Fulfiller[C]) {
+func NewLocalPromise[C ~ClientKind]() (C, Resolver[C]) {
 	lp := newLocalPromise()
 	p, f := NewPromisedClient(lp)
-	return C(p), localFulfiller[C]{
-		lp:              lp,
-		clientFulfiller: f,
+	return C(p), localResolver[C]{
+		lp:             lp,
+		clientResolver: f,
 	}
 }
 
@@ -54,17 +54,17 @@ func (lp localPromise) Reject(err error) {
 	lp.aq.Reject(err)
 }
 
-type localFulfiller[C ~ClientKind] struct {
-	lp              localPromise
-	clientFulfiller Fulfiller[Client]
+type localResolver[C ~ClientKind] struct {
+	lp             localPromise
+	clientResolver Resolver[Client]
 }
 
-func (lf localFulfiller[C]) Fulfill(c C) {
+func (lf localResolver[C]) Fulfill(c C) {
 	lf.lp.Fulfill(Client(c))
-	lf.clientFulfiller.Fulfill(Client(c))
+	lf.clientResolver.Fulfill(Client(c))
 }
 
-func (lf localFulfiller[C]) Reject(err error) {
+func (lf localResolver[C]) Reject(err error) {
 	lf.lp.Reject(err)
-	lf.clientFulfiller.Reject(err)
+	lf.clientResolver.Reject(err)
 }

--- a/rpc/level0_test.go
+++ b/rpc/level0_test.go
@@ -1964,7 +1964,12 @@ func (pingPongProvider) PingPong(ctx context.Context, call testcp.PingPongProvid
 type pingPonger struct{}
 
 func (pingPonger) EchoNum(ctx context.Context, call testcp.PingPong_echoNum) error {
-	panic("NOT IMPLEMENTED")
+	results, err := call.AllocResults()
+	if err != nil {
+		return err
+	}
+	results.SetN(call.Args().N())
+	return nil
 }
 
 // finishTest drains both sides of a pipe and reports any errors to t.

--- a/rpc/localpromise_test.go
+++ b/rpc/localpromise_test.go
@@ -27,6 +27,8 @@ func (e *echoNumOrderChecker) EchoNum(ctx context.Context, p testcapnp.PingPong_
 }
 
 func TestLocalPromiseFulfill(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	p, r := capnp.NewLocalPromise[testcapnp.PingPong]()
 	defer p.Release()
@@ -69,6 +71,8 @@ func TestLocalPromiseFulfill(t *testing.T) {
 }
 
 func TestLocalPromiseReject(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	p, r := capnp.NewLocalPromise[testcapnp.PingPong]()
 	defer p.Release()

--- a/rpc/localpromise_test.go
+++ b/rpc/localpromise_test.go
@@ -1,0 +1,86 @@
+package rpc_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"capnproto.org/go/capnp/v3"
+	"capnproto.org/go/capnp/v3/rpc/internal/testcapnp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLocalPromiseFulfill(t *testing.T) {
+	ctx := context.Background()
+	p, r := capnp.NewLocalPromise[testcapnp.PingPong]()
+	defer p.Release()
+
+	fut1, rel1 := p.EchoNum(ctx, func(p testcapnp.PingPong_echoNum_Params) error {
+		p.SetN(1)
+		return nil
+	})
+	defer rel1()
+
+	fut2, rel2 := p.EchoNum(ctx, func(p testcapnp.PingPong_echoNum_Params) error {
+		p.SetN(2)
+		return nil
+	})
+	defer rel2()
+
+	pp := testcapnp.PingPong_ServerToClient(&pingPonger{})
+	defer pp.Release()
+	r.Fulfill(pp)
+
+	fut3, rel3 := p.EchoNum(ctx, func(p testcapnp.PingPong_echoNum_Params) error {
+		p.SetN(3)
+		return nil
+	})
+	defer rel3()
+
+	res1, err := fut1.Struct()
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), res1.N())
+
+	res2, err := fut2.Struct()
+	assert.NoError(t, err)
+	assert.Equal(t, int64(2), res2.N())
+
+	res3, err := fut3.Struct()
+	assert.NoError(t, err)
+	assert.Equal(t, int64(3), res3.N())
+}
+
+func TestLocalPromiseReject(t *testing.T) {
+	ctx := context.Background()
+	p, r := capnp.NewLocalPromise[testcapnp.PingPong]()
+	defer p.Release()
+
+	fut1, rel1 := p.EchoNum(ctx, func(p testcapnp.PingPong_echoNum_Params) error {
+		p.SetN(1)
+		return nil
+	})
+	defer rel1()
+
+	fut2, rel2 := p.EchoNum(ctx, func(p testcapnp.PingPong_echoNum_Params) error {
+		p.SetN(2)
+		return nil
+	})
+	defer rel2()
+
+	r.Reject(errors.New("Promise rejected"))
+
+	fut3, rel3 := p.EchoNum(ctx, func(p testcapnp.PingPong_echoNum_Params) error {
+		p.SetN(3)
+		return nil
+	})
+	defer rel3()
+
+	_, err := fut1.Struct()
+	assert.NotNil(t, err)
+
+	_, err = fut2.Struct()
+	assert.NotNil(t, err)
+
+	_, err = fut3.Struct()
+	assert.NotNil(t, err)
+}

--- a/rpc/question.go
+++ b/rpc/question.go
@@ -15,7 +15,7 @@ type question struct {
 	c  *Conn
 	id questionID
 
-	bootstrapPromise capnp.Fulfiller[capnp.Client]
+	bootstrapPromise capnp.Resolver[capnp.Client]
 
 	p       *capnp.Promise
 	release capnp.ReleaseFunc // written before resolving p

--- a/rpc/question.go
+++ b/rpc/question.go
@@ -15,7 +15,7 @@ type question struct {
 	c  *Conn
 	id questionID
 
-	bootstrapPromise *capnp.ClientPromise
+	bootstrapPromise capnp.Fulfiller[capnp.Client]
 
 	p       *capnp.Promise
 	release capnp.ReleaseFunc // written before resolving p


### PR DESCRIPTION
Stacked on top of #475; merge that first.

This introduces a new function NewLocalPromise() which is similar to NewPromisedClient, but (1) is generic in the client type, so you can use it directly with anything that satisfies `~ClientKind`, and (2) doesn't take the `ClientHook` parameter, instead buffering calls in memory until the promise is fulfilled.

I haven't tested this, so I'm marking it as a draft.

I'm also not crazy about the names; I feel like we have too many distinct things called promise, and fewer of them should be exported anyway...