### PR TITLE
Remove more uses of fmt.

### DIFF
--- a/capnpc-go/fileparts.go
+++ b/capnpc-go/fileparts.go
@@ -21,7 +21,6 @@ var (
 		{path: flowcontrolImport, name: "fc"},
 
 		// stdlib imports
-		{path: "fmt", name: "fmt"},
 		{path: "context", name: "context"},
 		{path: "math", name: "math"},
 		{path: "strconv", name: "strconv"},
@@ -104,10 +103,6 @@ func (i *imports) Text() string {
 
 func (i *imports) FlowControl() string {
 	return i.add(importSpec{path: flowcontrolImport, name: "fc"})
-}
-
-func (i *imports) Fmt() string {
-	return i.add(importSpec{path: "fmt", name: "fmt"})
 }
 
 func (i *imports) Context() string {

--- a/capnpc-go/templates/interfaceClient
+++ b/capnpc-go/templates/interfaceClient
@@ -39,7 +39,7 @@ func (c {{$.Node.Name}}) WaitStreaming() error {
 // should not be used to compare clients.  Use IsSame to compare clients
 // for equality.
 func (c {{$.Node.Name}}) String() string {
-	return {{$.G.Imports.Fmt}}.Sprintf("%T(%v)", c, capnp.Client(c))
+	return "{{$.Node.Name}}(" + capnp.Client(c).String() + ")"
 }
 
 // AddRef creates a new Client that refers to the same capability as c.

--- a/flowcontrol/internal/test-tool/writer.capnp.go
+++ b/flowcontrol/internal/test-tool/writer.capnp.go
@@ -9,7 +9,6 @@ import (
 	schemas "capnproto.org/go/capnp/v3/schemas"
 	server "capnproto.org/go/capnp/v3/server"
 	context "context"
-	fmt "fmt"
 )
 
 type Writer capnp.Client
@@ -46,7 +45,7 @@ func (c Writer) WaitStreaming() error {
 // should not be used to compare clients.  Use IsSame to compare clients
 // for equality.
 func (c Writer) String() string {
-	return fmt.Sprintf("%T(%v)", c, capnp.Client(c))
+	return "Writer(" + capnp.Client(c).String() + ")"
 }
 
 // AddRef creates a new Client that refers to the same capability as c.

--- a/internal/aircraftlib/aircraft.capnp.go
+++ b/internal/aircraftlib/aircraft.capnp.go
@@ -9,7 +9,6 @@ import (
 	schemas "capnproto.org/go/capnp/v3/schemas"
 	server "capnproto.org/go/capnp/v3/server"
 	context "context"
-	fmt "fmt"
 	math "math"
 	strconv "strconv"
 )
@@ -5082,7 +5081,7 @@ func (c Echo) WaitStreaming() error {
 // should not be used to compare clients.  Use IsSame to compare clients
 // for equality.
 func (c Echo) String() string {
-	return fmt.Sprintf("%T(%v)", c, capnp.Client(c))
+	return "Echo(" + capnp.Client(c).String() + ")"
 }
 
 // AddRef creates a new Client that refers to the same capability as c.
@@ -5876,7 +5875,7 @@ func (c CallSequence) WaitStreaming() error {
 // should not be used to compare clients.  Use IsSame to compare clients
 // for equality.
 func (c CallSequence) String() string {
-	return fmt.Sprintf("%T(%v)", c, capnp.Client(c))
+	return "CallSequence(" + capnp.Client(c).String() + ")"
 }
 
 // AddRef creates a new Client that refers to the same capability as c.
@@ -6194,7 +6193,7 @@ func (c Pipeliner) WaitStreaming() error {
 // should not be used to compare clients.  Use IsSame to compare clients
 // for equality.
 func (c Pipeliner) String() string {
-	return fmt.Sprintf("%T(%v)", c, capnp.Client(c))
+	return "Pipeliner(" + capnp.Client(c).String() + ")"
 }
 
 // AddRef creates a new Client that refers to the same capability as c.

--- a/list.go
+++ b/list.go
@@ -1,9 +1,7 @@
 package capnp
 
 import (
-	"bytes"
 	"errors"
-	"fmt"
 	"math"
 	"strconv"
 
@@ -1078,20 +1076,6 @@ func (s StructList[T]) At(i int) T {
 // Set sets the i'th element to v.
 func (s StructList[T]) Set(i int, v T) error {
 	return List(s).SetStruct(i, Struct(v))
-}
-
-// String returns the list in Cap'n Proto schema format (e.g. "[(x = 1), (x = 2)]").
-func (s StructList[T]) String() string {
-	buf := &bytes.Buffer{}
-	buf.WriteByte('[')
-	for i := 0; i < s.Len(); i++ {
-		if i > 0 {
-			buf.WriteString(", ")
-		}
-		fmt.Fprint(buf, s.At(i))
-	}
-	buf.WriteByte(']')
-	return buf.String()
 }
 
 // A list of some Cap'n Proto capability type T.

--- a/rpc/internal/testcapnp/test.capnp.go
+++ b/rpc/internal/testcapnp/test.capnp.go
@@ -10,7 +10,6 @@ import (
 	server "capnproto.org/go/capnp/v3/server"
 	stream "capnproto.org/go/capnp/v3/std/capnp/stream"
 	context "context"
-	fmt "fmt"
 )
 
 type PingPong capnp.Client
@@ -47,7 +46,7 @@ func (c PingPong) WaitStreaming() error {
 // should not be used to compare clients.  Use IsSame to compare clients
 // for equality.
 func (c PingPong) String() string {
-	return fmt.Sprintf("%T(%v)", c, capnp.Client(c))
+	return "PingPong(" + capnp.Client(c).String() + ")"
 }
 
 // AddRef creates a new Client that refers to the same capability as c.
@@ -350,7 +349,7 @@ func (c StreamTest) WaitStreaming() error {
 // should not be used to compare clients.  Use IsSame to compare clients
 // for equality.
 func (c StreamTest) String() string {
-	return fmt.Sprintf("%T(%v)", c, capnp.Client(c))
+	return "StreamTest(" + capnp.Client(c).String() + ")"
 }
 
 // AddRef creates a new Client that refers to the same capability as c.
@@ -608,7 +607,7 @@ func (c CapArgsTest) WaitStreaming() error {
 // should not be used to compare clients.  Use IsSame to compare clients
 // for equality.
 func (c CapArgsTest) String() string {
-	return fmt.Sprintf("%T(%v)", c, capnp.Client(c))
+	return "CapArgsTest(" + capnp.Client(c).String() + ")"
 }
 
 // AddRef creates a new Client that refers to the same capability as c.
@@ -1100,7 +1099,7 @@ func (c PingPongProvider) WaitStreaming() error {
 // should not be used to compare clients.  Use IsSame to compare clients
 // for equality.
 func (c PingPongProvider) String() string {
-	return fmt.Sprintf("%T(%v)", c, capnp.Client(c))
+	return "PingPongProvider(" + capnp.Client(c).String() + ")"
 }
 
 // AddRef creates a new Client that refers to the same capability as c.

--- a/schemas/schemas.go
+++ b/schemas/schemas.go
@@ -12,12 +12,12 @@ import (
 	"bytes"
 	"compress/zlib"
 	"errors"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"strings"
 	"sync"
 
+	"capnproto.org/go/capnp/v3/internal/str"
 	"capnproto.org/go/capnp/v3/packed"
 )
 
@@ -164,7 +164,7 @@ type dupeError struct {
 }
 
 func (e *dupeError) Error() string {
-	return fmt.Sprintf("schemas: registered @%#x twice", e.id)
+	return "schemas: registered @" + str.UToHex(e.id) + " twice"
 }
 
 type notFoundError struct {
@@ -172,7 +172,7 @@ type notFoundError struct {
 }
 
 func (e *notFoundError) Error() string {
-	return fmt.Sprintf("schemas: could not find @%#x", e.id)
+	return "schemas: could not find @" + str.UToHex(e.id)
 }
 
 type decompressError struct {
@@ -181,5 +181,5 @@ type decompressError struct {
 }
 
 func (e *decompressError) Error() string {
-	return fmt.Sprintf("schemas: decompressing schema for @%#x: %v", e.id, e.err)
+	return "schemas: decompressing schema for @" + str.UToHex(e.id) + ": " + e.err.Error()
 }

--- a/std/capnp/persistent/persistent.capnp.go
+++ b/std/capnp/persistent/persistent.capnp.go
@@ -9,7 +9,6 @@ import (
 	schemas "capnproto.org/go/capnp/v3/schemas"
 	server "capnproto.org/go/capnp/v3/server"
 	context "context"
-	fmt "fmt"
 )
 
 const PersistentAnnotation = uint64(0xf622595091cafb67)
@@ -48,7 +47,7 @@ func (c Persistent) WaitStreaming() error {
 // should not be used to compare clients.  Use IsSame to compare clients
 // for equality.
 func (c Persistent) String() string {
-	return fmt.Sprintf("%T(%v)", c, capnp.Client(c))
+	return "Persistent(" + capnp.Client(c).String() + ")"
 }
 
 // AddRef creates a new Client that refers to the same capability as c.


### PR DESCRIPTION
This patch:

- Drops a number of String() methods that require use of fmt, or importing the encoding/text subpackage.
- Avoids use of fmt in the schemas package.

After this patch, tempest's UI only pulls in fmt as a dependency of errgroup. I may look to see if we can avoid errgroup or build a lightweight alternative...