### PR TITLE
reduce 'arena not empty' error allocation

### DIFF
--- a/message.go
+++ b/message.go
@@ -100,6 +100,8 @@ func NewMultiSegmentMessage(b [][]byte) (msg *Message, first *Segment) {
 	return msg, first
 }
 
+var errArenaNotEmpty = errors.New("new message: arena not empty")
+
 // Reset the message to use a different arena, allowing it
 // to be reused. This invalidates any existing pointers in
 // the Message, and releases all clients in the cap table,
@@ -127,11 +129,11 @@ func (m *Message) Reset(arena Arena) (first *Segment, err error) {
 				return nil, exc.WrapError("new message", err)
 			}
 			if len(first.data) > 0 {
-				return nil, errors.New("new message: arena not empty")
+				return nil, errArenaNotEmpty
 			}
 
 		default:
-			return nil, errors.New("new message: arena not empty")
+			return nil, errArenaNotEmpty
 		}
 
 		if first.ID() != 0 {


### PR DESCRIPTION
tl;dr: This PR preallocates `new message: arena not empty` error to improve performance. 

At this point I'm not sure yet whether the fact that `Decode` indirectly produces `new message: arena not empty` error is something expected, a bug or maybe a misuse on my end. Nevertheless it is a bit wasteful. CPU profile of a test that consumes over 1M messages looks like this:

<img width="558" alt="image" src="https://user-images.githubusercontent.com/2438924/226325826-ac8ada10-a1c8-42af-aae5-a5b0c5bae125.png">

And after the change:
<img width="419" alt="image" src="https://user-images.githubusercontent.com/2438924/226325919-4d6e7d45-57dc-42b2-ba17-0cc43b745b42.png">

