### PR TITLE
Expunge io/ioutil

### DIFF
--- a/capnpc-go/capnpc-go_test.go
+++ b/capnpc-go/capnpc-go_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -19,7 +19,7 @@ import (
 
 func readTestFile(name string) ([]byte, error) {
 	path := filepath.Join("testdata", name)
-	return ioutil.ReadFile(path)
+	return os.ReadFile(path)
 }
 
 func mustReadTestFile(t *testing.T, name string) []byte {

--- a/encoding/text/marshal_test.go
+++ b/encoding/text/marshal_test.go
@@ -2,7 +2,7 @@ package text
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -13,7 +13,7 @@ import (
 
 func readTestFile(name string) ([]byte, error) {
 	path := filepath.Join("testdata", name)
-	return ioutil.ReadFile(path)
+	return os.ReadFile(path)
 }
 
 func TestEncode(t *testing.T) {

--- a/example_test.go
+++ b/example_test.go
@@ -2,7 +2,6 @@ package capnp_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"capnproto.org/go/capnp/v3"
@@ -75,7 +74,7 @@ func Example() {
 	_ = buf
 
 	// ... or write to an io.Writer.
-	file, err := ioutil.TempFile("", "go-capnproto")
+	file, err := os.CreateTemp("", "go-capnproto")
 	if err != nil {
 		panic(err)
 	}

--- a/packed/fuzz.go
+++ b/packed/fuzz.go
@@ -11,7 +11,6 @@ import (
 	"bufio"
 	"bytes"
 	"io"
-	"io/ioutil"
 )
 
 func Fuzz(data []byte) int {
@@ -26,7 +25,7 @@ func Fuzz(data []byte) int {
 	// Read
 	{
 		r := NewReader(bufio.NewReader(bytes.NewReader(data)))
-		if unpacked, err := ioutil.ReadAll(r); err == nil {
+		if unpacked, err := io.ReadAll(r); err == nil {
 			checkRepack(unpacked)
 			result = 1
 		}

--- a/packed/packed_test.go
+++ b/packed/packed_test.go
@@ -6,7 +6,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"strings"
 	"testing"
@@ -381,7 +380,7 @@ func TestReader_Fail(t *testing.T) {
 	for _, test := range badDecompressionTests {
 		t.Run(test.name, func(t *testing.T) {
 			d := NewReader(bufio.NewReader(bytes.NewReader(test.input)))
-			_, err := ioutil.ReadAll(d)
+			_, err := io.ReadAll(d)
 			assert.Error(t, err, "should return error")
 		})
 	}
@@ -521,7 +520,7 @@ func mustGunzip(s string) []byte {
 	if err != nil {
 		panic(err)
 	}
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		panic(err)
 	}

--- a/schemas/schemas.go
+++ b/schemas/schemas.go
@@ -13,7 +13,6 @@ import (
 	"compress/zlib"
 	"errors"
 	"io"
-	"io/ioutil"
 	"strings"
 	"sync"
 
@@ -111,7 +110,7 @@ func (r *record) read() ([]byte, error) {
 			return
 		}
 		p := packed.NewReader(bufio.NewReader(z))
-		r.data, r.err = ioutil.ReadAll(p)
+		r.data, r.err = io.ReadAll(p)
 		if err != nil {
 			r.data = nil
 			return


### PR DESCRIPTION
Deprecated since go 1.16.  No functional changes.