### PR TITLE
Use go-util's mutex package for clientHook state.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/tinylib/msgp v1.1.5
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
-	zenhack.net/go/util v0.0.0-20230218002511-744d2d6d1739
+	zenhack.net/go/util v0.0.0-20230327231740-da8cb323921c
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -40,3 +40,5 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 zenhack.net/go/util v0.0.0-20230218002511-744d2d6d1739 h1:/QnbZBURrZUFvnxB4wDyRrPsWzh2KWbJ6AjUjohCHJ8=
 zenhack.net/go/util v0.0.0-20230218002511-744d2d6d1739/go.mod h1:0lafdGg7tDb7RcXASgmJmRbLFLkAxu328+KGIs7icDE=
+zenhack.net/go/util v0.0.0-20230327231740-da8cb323921c h1:L+T38E+u91e956ykUrYKHZaZef9hKMJsnGmTbMVb2cE=
+zenhack.net/go/util v0.0.0-20230327231740-da8cb323921c/go.mod h1:0lafdGg7tDb7RcXASgmJmRbLFLkAxu328+KGIs7icDE=


### PR DESCRIPTION
Note: this depends on https://github.com/zenhack/go-util/pull/1.

I want to use this basically everywhere else we're using a mutex as well, but I to stay sane while reworking Client internals I wanted to do this now. I just did clientHook to keep this PR small-ish, but expect similar for related data structures soon.