### PR TITLE
Decompose answer struct.

### DIFF
--- a/rpc/answer.go
+++ b/rpc/answer.go
@@ -268,7 +268,7 @@ func (ans *ansent) prepareSendReturn(c *lockedConn, rl *releaseList) {
 	select {
 	case <-c.bgctx.Done():
 		// We're not going to send the message after all, so don't forget to release it.
-		ans.returner.msgReleaser.Decr()
+		rl.Add(ans.returner.msgReleaser.Decr)
 		ans.sendMsg = nil
 	default:
 	}

--- a/rpc/answer.go
+++ b/rpc/answer.go
@@ -45,6 +45,10 @@ type ansent struct {
 	// the argument should be the same as ans.c
 	sendMsg func(*lockedConn)
 
+	// cancel cancels the Context used in the received method call.
+	// May be nil.
+	cancel context.CancelFunc
+
 	// Unlike other fields in this struct, it is ok to hand out pointers
 	// to this that can be used while not holding the connection lock.
 	returner ansReturner
@@ -56,10 +60,6 @@ type ansReturner struct {
 	// c and id must be set before any answer methods are called.
 	c  *Conn
 	id answerID
-
-	// cancel cancels the Context used in the received method call.
-	// May be nil.
-	cancel context.CancelFunc
 
 	// ret is the outgoing Return struct.  ret is valid iff there was no
 	// error creating the message.  If ret is invalid, then this answer


### PR DESCRIPTION
This splits the `answer` struct in the rpc package into `ansent` and `ansReturner`, which makes it more similar to e.g. `impent`/`importClient`. This should make this generally easier to understand and work with.

Along the way I spotted a place where we were violating a documented invariant, and fixed it (9161f0e8d63c1b09060c2228037c6d5f6e04e786). Otherwise there is no functional change.