### PR TITLE
exc.WrapError: return nil if the original error is nil.

### DIFF
--- a/exc/exc.go
+++ b/exc/exc.go
@@ -27,6 +27,9 @@ func (e wrappedError) Unwrap() error {
 }
 
 func WrapError(prefix string, err error) error {
+	if err == nil {
+		return nil
+	}
 	return wrappedError{
 		prefix: prefix,
 		base:   err,


### PR DESCRIPTION
I'm finding this convenient in Tempest