### PR TITLE
Remove superfluous call to Release() in test.

### DIFF
--- a/rpc/receiveranswer_test.go
+++ b/rpc/receiveranswer_test.go
@@ -118,7 +118,6 @@ func TestCallReceiverAnswerRpc(t *testing.T) {
 	callRes, rel := self.Call(ctx, func(p testcapnp.CapArgsTest_call_Params) error {
 		return p.SetCap(capnp.Client(self.AddRef()))
 	})
-	self.Release()
 	defer rel()
 
 	_, err := selfRes.Struct()


### PR DESCRIPTION
I think this is harmless, because Release() is idempotent, but the call to rel() already covers this.