### PR TITLE
Don't use $GOPATH in instructions.

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -11,8 +11,10 @@ capnpc-go provides the compiler backend for capnp.
 
 	# First, install capnpc-go to $PATH.
 	go install capnproto.org/go/capnp/v3/capnpc-go
+	# Then, check out the go-capnp source code:
+	git clone https://github.com/capnproto/go-capnp /desired/path/to/go-capnp
 	# Then, generate Go files.
-	capnp compile -I$GOPATH/src/capnproto.org/go/capnp/v3/std -ogo *.capnp
+	capnp compile -I /desired/path/to/go-capnp/std -ogo *.capnp
 
 capnpc-go requires two annotations for all files: package and import.
 package is needed to know what package to place at the head of the

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -2,14 +2,22 @@
 
 First, [install the Cap'n Proto tools](https://capnproto.org/install.html).
 
-Then, run the following commands to install the compiler plugin for the Go language:
+Then, run the following command to install the compiler plugin for the
+Go language:
 
 ```bash
 $ go install capnproto.org/go/capnp/v3/capnpc-go@latest  # install go compiler plugin
-$ GO111MODULE=off go get -u capnproto.org/go/capnp/v3/   # install go-capnproto to $GOPATH
 ```
 
-Lastly, ensure `$GOPATH/bin` has been added to your shell's `$PATH` variable.
+This will install a `capnpc-go` executable under `$(go env GOPATH)/bin`,
+which you should make sure has been added to your shell's `$PATH` variable.
+
+You will also need a checkout of of the `go-capnp` repository, for the
+included schema:
+
+```
+$ git clone https://github.com/capnproto/go-capnp
+```
 
 If you get stuck at any point, please [ask us for help](https://matrix.to/#/#go-capnp:matrix.org)!
 

--- a/docs/Remote-Procedure-Calls-using-Interfaces.md
+++ b/docs/Remote-Procedure-Calls-using-Interfaces.md
@@ -55,7 +55,7 @@ interface Arith {
 
 Now, compile the schema as before:
 ```bash
-capnp compile -I$GOPATH/src/capnproto.org/go/capnp/std -ogo arith.capnp
+capnp compile -I /path/to/go-capnp/std -ogo arith.capnp
 ```
 
 You should take a moment to inspect the generated types in `arith.capnp.go`.  For interface declarations in your schema, the capnp compiler generates several types, summarized in the following tables.

--- a/docs/Writing-Schemas-and-Generating-Code.md
+++ b/docs/Writing-Schemas-and-Generating-Code.md
@@ -41,7 +41,7 @@ Compilation will fail unless these annotations are present.
 To compile this schema into Go code, run the following command.   Note that the source path `/foo/books.capnp` must correspond to the import path declared in your annotations.
 
 ```bash
-capnp compile -I$GOPATH/src/capnproto.org/go/capnp/std -ogo foo/books.capnp
+capnp compile -I /path/to/go-capnp/std -ogo foo/books.capnp
 ```
 
 > **Tip** 👉 For more compilation options, see `capnp compile --help`.

--- a/example/books/README.md
+++ b/example/books/README.md
@@ -3,7 +3,7 @@ capnproto schema:
 
 ```
 cd $GOPATH/src/go-capnproto2/example/books
-capnp compile -I/home/johnk/go/src/capnproto.org/go/capnp/std/ -ogo books/books.capnp
+capnp compile -I ../../std/ -ogo books/books.capnp
 ```
 
 Then build and run each example:

--- a/example/hashes/README.md
+++ b/example/hashes/README.md
@@ -1,10 +1,10 @@
-cd to wherever you installed the source, for example:
+cd to wherever you installed the source:
 
-`cd $GOPATH/src/go-capnproto2/example/hashes`
+`cd /path/to/go-capnp/example/hashes`
 
 Compile the capnp file:
 
-`capnp compile -I$GOPATH/src/capnproto.org/go/capnp/std/ -ogo hashes/hashes.capnp`
+`capnp compile -I ../../std/ -ogo hashes.capnp`
 
 Build your code, and run it:
 


### PR DESCRIPTION
Per some prior discussions, GOPATH is basically dead at this point, and using it here obscures what's really going on: you just need the code checked out somewhere so you can pass -I /path/to/go-capnp/std to capnp compile