### PR TITLE
Use ClientSnapshot in the export table, rather than Client

### DIFF
--- a/capability.go
+++ b/capability.go
@@ -640,7 +640,7 @@ func (cs ClientSnapshot) AddRef() ClientSnapshot {
 }
 
 // Release the reference to the hook.
-func (cs ClientSnapshot) Release() {
+func (cs *ClientSnapshot) Release() {
 	cs.hook.Release()
 }
 

--- a/capability.go
+++ b/capability.go
@@ -566,7 +566,9 @@ func (c Client) WeakRef() WeakClient {
 // ClientSnapshot if c is nil, has resolved to null, or has been released.
 func (c Client) Snapshot() ClientSnapshot {
 	h, _, _ := c.startCall()
-	return ClientSnapshot{hook: h}
+	s := ClientSnapshot{hook: h}
+	setupLeakReporting(s)
+	return s
 }
 
 // A Brand is an opaque value used to identify a capability.
@@ -636,6 +638,7 @@ func (cs ClientSnapshot) Metadata() *Metadata {
 // Create a copy of the snapshot, with its own underlying reference.
 func (cs ClientSnapshot) AddRef() ClientSnapshot {
 	cs.hook = cs.hook.AddRef()
+	setupLeakReporting(cs)
 	return cs
 }
 
@@ -647,6 +650,7 @@ func (cs *ClientSnapshot) Release() {
 func (cs *ClientSnapshot) Resolve1(ctx context.Context) error {
 	var err error
 	cs.hook, _, err = resolve1ClientHook(ctx, cs.hook)
+	setupLeakReporting(*cs)
 	return err
 }
 
@@ -658,6 +662,7 @@ func (cs *ClientSnapshot) resolve1(ctx context.Context) (more bool, err error) {
 func (cs *ClientSnapshot) Resolve(ctx context.Context) error {
 	var err error
 	cs.hook, err = resolveClientHook(ctx, cs.hook)
+	setupLeakReporting(*cs)
 	return err
 }
 
@@ -766,7 +771,7 @@ func (s *resolveState) isResolved() bool {
 	}
 }
 
-var setupLeakReporting func(Client) = func(Client) {}
+var setupLeakReporting func(any) = func(any) {}
 
 // SetClientLeakFunc sets a callback for reporting Clients that went
 // out of scope without being released.  The callback is not guaranteed
@@ -776,20 +781,32 @@ var setupLeakReporting func(Client) = func(Client) {}
 // SetClientLeakFunc must not be called after any calls to NewClient or
 // NewPromisedClient.
 func SetClientLeakFunc(clientLeakFunc func(msg string)) {
-	setupLeakReporting = func(c Client) {
+	setupLeakReporting = func(v any) {
 		buf := bufferpool.Default.Get(1e6)
 		n := runtime.Stack(buf, false)
 		stack := string(buf[:n])
 		bufferpool.Default.Put(buf)
-		runtime.SetFinalizer(c.client, func(c *client) {
-			released := mutex.With1(&c.state, func(c *clientState) bool {
-				return c.released
+		switch c := v.(type) {
+		case Client:
+			runtime.SetFinalizer(c.client, func(c *client) {
+				released := mutex.With1(&c.state, func(c *clientState) bool {
+					return c.released
+				})
+				if released {
+					return
+				}
+				clientLeakFunc("leaked client created at:\n\n" + stack)
 			})
-			if released {
-				return
-			}
-			clientLeakFunc("leaked client created at:\n\n" + stack)
-		})
+		case ClientSnapshot:
+			runtime.SetFinalizer(c.hook, func(c *rc.Ref[clientHook]) {
+				if !c.IsValid() {
+					return
+				}
+				clientLeakFunc("leaked client snapshot created at:\n\n" + stack)
+			})
+		default:
+			panic("setupLeakReporting called on unrecognized type!")
+		}
 	}
 }
 

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -457,13 +457,11 @@ func (c *lockedConn) releaseBootstrap(dq *deferred.Queue) {
 func (c *lockedConn) releaseExports(dq *deferred.Queue, exports []*expent) {
 	for _, e := range exports {
 		if e != nil {
-			snapshot := e.client.Snapshot()
-			metadata := snapshot.Metadata()
+			metadata := e.snapshot.Metadata()
 			syncutil.With(metadata, func() {
 				c.clearExportID(metadata)
 			})
-			snapshot.Release()
-			dq.Defer(e.client.Release)
+			dq.Defer(e.snapshot.Release)
 		}
 	}
 }
@@ -660,13 +658,13 @@ func (c *Conn) handleUnimplemented(in transport.IncomingMessage) error {
 			default:
 				return nil
 			}
-			client, err := withLockedConn2(c, func(c *lockedConn) (capnp.Client, error) {
+			snapshot, err := withLockedConn2(c, func(c *lockedConn) (capnp.ClientSnapshot, error) {
 				return c.releaseExport(id, 1)
 			})
 			if err != nil {
 				return err
 			}
-			client.Release()
+			snapshot.Release()
 			return nil
 		}
 	}
@@ -854,7 +852,7 @@ func (c *Conn) handleCall(ctx context.Context, in transport.IncomingMessage) err
 			pcall := newPromisedPipelineCaller()
 			ans.setPipelineCaller(p.method, pcall)
 			dq.Defer(func() {
-				pcall.resolve(ent.client.RecvCall(callCtx, recv))
+				pcall.resolve(ent.snapshot.Recv(callCtx, recv))
 			})
 			return nil
 		case rpccp.MessageTarget_Which_promisedAnswer:
@@ -1349,7 +1347,7 @@ func (c *lockedConn) recvCap(d rpccp.CapDescriptor) (capnp.Client, error) {
 				"receive capability: invalid export " + str.Utod(id),
 			))
 		}
-		return ent.client.AddRef(), nil
+		return ent.snapshot.Client(), nil
 	case rpccp.CapDescriptor_Which_receiverAnswer:
 		promisedAnswer, err := d.ReceiverAnswer()
 		if err != nil {
@@ -1525,14 +1523,13 @@ func (c *Conn) handleRelease(ctx context.Context, in transport.IncomingMessage) 
 	id := exportID(rel.Id())
 	count := rel.ReferenceCount()
 
-	var client capnp.Client
-	c.withLocked(func(c *lockedConn) {
-		client, err = c.releaseExport(id, count)
+	snapshot, err := withLockedConn2(c, func(c *lockedConn) (capnp.ClientSnapshot, error) {
+		return c.releaseExport(id, count)
 	})
 	if err != nil {
 		return rpcerr.Annotate(err, "incoming release")
 	}
-	client.Release() // no-ops for nil
+	snapshot.Release() // no-ops for nil
 	return nil
 }
 


### PR DESCRIPTION
This also tweaks the leak reporting to also check snapshots.