### PR TITLE
Pipelined calls on snapshots

### DIFF
--- a/capability.go
+++ b/capability.go
@@ -596,11 +596,18 @@ func (cs ClientSnapshot) IsPromise() bool {
 
 // Send implements ClientHook.Send
 func (cs ClientSnapshot) Send(ctx context.Context, s Send) (*Answer, ReleaseFunc) {
+	if cs.hook == nil {
+		return ErrorAnswer(s.Method, errors.New("call on null client")), func() {}
+	}
 	return cs.hook.Value().Send(ctx, s)
 }
 
 // Recv implements ClientHook.Recv
 func (cs ClientSnapshot) Recv(ctx context.Context, r Recv) PipelineCaller {
+	if cs.hook == nil {
+		r.Reject(errors.New("call on null client"))
+		return nil
+	}
 	return cs.hook.Value().Recv(ctx, r)
 }
 

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -478,8 +478,13 @@ func (c *lockedConn) liftEmbargoes(dq *deferred.Queue, embargoes []*embargo) {
 
 func (c *lockedConn) releaseAnswers(dq *deferred.Queue, answers map[answerID]*ansent) {
 	for _, a := range answers {
-		if a != nil && a.returner.msgReleaser != nil {
-			dq.Defer(a.returner.msgReleaser.Decr)
+		if a != nil {
+			for _, s := range a.returner.resultsCapTable {
+				dq.Defer(s.Release)
+			}
+			if a.returner.msgReleaser != nil {
+				dq.Defer(a.returner.msgReleaser.Decr)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Related to #520, this handles the answers table side of the 4-way race fix.