### PR TITLE
RegisterSchema per golang package #490: include all schema nodes

### DIFF
--- a/capnpc-go/nodes.go
+++ b/capnpc-go/nodes.go
@@ -275,10 +275,8 @@ func makeNodeTrees(req schema.CodeGeneratorRequest) (nodeTrees, error) {
 		f.pkg = ann.Package
 		f.imp = ann.Import
 		nnodes, _ := f.NestedNodes()
-		ids := make([]uint64, nnodes.Len())
 		for i := 0; i < nnodes.Len(); i++ {
 			nn := nnodes.At(i)
-			ids[i] = nn.Id()
 			if ni := ret.nodes[nn.Id()]; ni != nil {
 				nname, _ := nn.Name()
 				if err := resolveName(ret.nodes, ni, "", nname, f); err != nil {
@@ -294,7 +292,9 @@ func makeNodeTrees(req schema.CodeGeneratorRequest) (nodeTrees, error) {
 		}
 		// Note that this can collect ids from multiple files if they are in the
 		// same $Go.package.
-		pkg.nodeId = append(pkg.nodeId, ids...)
+		for _, n := range f.nodes {
+			pkg.nodeId = append(pkg.nodeId, n.Id())
+		}
 		ret.pkgs[f.pkg] = pkg
 	}
 	return ret, nil


### PR DESCRIPTION
There are missing nodes in RegisterSchemas. For instance, https://github.com/capnproto/go-capnp/blob/main/flowcontrol/internal/test-tool/writer.capnp.go is generated with only the top-level ID in the list of Nodes:

```
$ cd capnpc-go
capnpc-go $ go build
capnpc-go $ (  cd ../flowcontrol/internal/test-tool && capnp compile --no-standard-import -I../../../std -o- writer.capnp ) | capnpc-go
capnpc-go $ mv writer.capnp.go ../flowcontrol/internal/test-tool/writer.capnp.go
capnpc-go $ git diff ../flowcontrol/internal/test-tool/writer.capnp.go
diff --git a/flowcontrol/internal/test-tool/writer.capnp.go b/flowcontrol/internal/test-tool/writer.capnp.go
index 3f5d8e1..2089ab9 100644
--- a/flowcontrol/internal/test-tool/writer.capnp.go
+++ b/flowcontrol/internal/test-tool/writer.capnp.go
@@ -314,28 +314,20 @@ func (f Writer_write_Results_Future) Struct() (Writer_write_Results, error) {
        return Writer_write_Results(p.Struct()), err
 }
 
-const schema_aca73f831c7ebfdd = "x\xda\x12\xa8u`1\xe4\xcdgb`\x0a\x94ae" +
-       "\xfb_~\xe4\xb1K\xfc\xd9\x1d\x0d\x0c\x82\"\x8c\x0c\x0c" +
-       "\xac\x8c\xec\x0c\x0c\xc6\xb2\x8c\\\x8c\x0c\x8c\xc2\xaa\x8c\xf6" +
-       "\x0c\x8c\xff\x7f<WI\xe8\xb9gy\x13\xa2\x80\x05$" +
-       "\xef\xca(\xc4\xc8\xc0\xf2?[\xb8\x7f\xf9\x96\x08\xbd\x1f" +
-       "\x0c\x82\xbc\xcc\xff\xef\xee\xaf\x93i\xb6_\xbe\x86\x81\x81" +
-       "QX\x97q\x91\xb0)\xc8$aCFw\xe1HF" +
-       "v\x06\x9d\xff\xe5E\x99%\xa9Ez\xc9\xcc\x89\x05y" +
-       "\x05V\xe1\x10\x1eXP% \xb1(1\xb7\x98\x81!" +
-       "\x90\x85\x99\x85\x81\x81\x85\x91\x81A\x90W\x8b\x81!\x90" +
-       "\x83\x991P\x84\x89\x91?%\xb1$\x91\x91\x97\x81\x89" +
-       "\x91\x97\x81\x11\x9f9A\xa9\xc5\xa59%\x8c\xc5p5" +
-       "\x8c05\xec%\xa9E\x01\x8c\x8c\x81,\xcc\xac\x0c\x0c" +
-       "p/3\xc2\xbc&(h\xc4\xc0$\xc8\xca.\x0f\xd6" +
-       "\xe8\xc0\x18\xc0\xc8\x08\x08\x00\x00\xff\xff\x1d\x88R\x0a"
+const schema_aca73f831c7ebfdd = "x\xda\x12Hv`1\xe4\xcdgb`\x0a\x94ae" +
+       "\xfb\x9f-\xdc\xbf|K\x84\xde\x0f\x06A^\xe6\xffw" +
+       "\xf7\xd7\xc94\xdb/_\xc3\xc0\xc0(,\xcb\xb8HX" +
+       "\x95\x91\x9d\x81AX\x91\xd1]\xd8\x93\x91\x9d\xc1\xe9\x7f" +
+       "yQfIj\x91^2cbA^\x81UxQ" +
+       "&{IjQ\x00#c \x0b3+\x03\xc3\xff\xf2" +
+       "#\x8f]\xe2\xcf\xeeh`\xfc\xf1\\%\xa1\xe7\x9e\xe5" +
+       "MAA#\x06&AVvy\xb0F\x07\xc6\x00F" +
+       "F@\x00\x00\x00\xff\xff\x1b\xae%\xa6"
 
 func RegisterSchema(reg *schemas.Registry) {
        reg.Register(&schemas.Schema{
                String: schema_aca73f831c7ebfdd,
                Nodes: []uint64{
-                       0x80b8cd5f44e3c477,
-                       0xd939de8c6024e7f8,
                        0xf82e58b4a78f136b,
                },
                Compressed: true,
```