### PR TITLE
Slight improvement in installation docs

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -6,7 +6,7 @@ Then, run the following command to install the compiler plugin for the
 Go language:
 
 ```bash
-$ go install capnproto.org/go/capnp/v3/capnpc-go@latest  # install go compiler plugin
+go install capnproto.org/go/capnp/v3/capnpc-go@latest
 ```
 
 This will install a `capnpc-go` executable under `$(go env GOPATH)/bin`,
@@ -16,7 +16,7 @@ You will also need a checkout of of the `go-capnp` repository, for the
 included schema:
 
 ```
-$ git clone https://github.com/capnproto/go-capnp
+git clone https://github.com/capnproto/go-capnp
 ```
 
 If you get stuck at any point, please [ask us for help](https://matrix.to/#/#go-capnp:matrix.org)!


### PR DESCRIPTION
Removed the use of dollar sign ($) so that the copy feature copies exactly what should go in the terminal. 

Before, what would be copied was:

`$ git clone https://github.com/capnproto/go-capnp`

After: 

`git clone https://github.com/capnproto/go-capnp`

