### PR TITLE
bufferpool: Switch to zeropool

### DIFF
--- a/exp/bufferpool/pool_test.go
+++ b/exp/bufferpool/pool_test.go
@@ -68,8 +68,17 @@ func TestPut(t *testing.T) {
 }
 
 func BenchmarkPool(b *testing.B) {
+	var pool bufferpool.Pool
+	const size = 32
+
+	// Make cache hot.
+	buf := pool.Get(size)
+	pool.Put(buf)
+
+	b.ResetTimer()
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		buf := bufferpool.Default.Get(32)
-		bufferpool.Default.Put(buf)
+		buf := pool.Get(size)
+		pool.Put(buf)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module capnproto.org/go/capnp/v3
 go 1.19
 
 require (
+	github.com/colega/zeropool v0.0.0-20230505084239-6fb4a4f75381
 	github.com/kylelemons/godebug v1.1.0
 	github.com/stretchr/testify v1.8.2
 	github.com/tinylib/msgp v1.1.5

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/colega/zeropool v0.0.0-20230505084239-6fb4a4f75381 h1:d5EKgQfRQvO97jnISfR89AiCCCJMwMFoSxUiU0OGCRU=
+github.com/colega/zeropool v0.0.0-20230505084239-6fb4a4f75381/go.mod h1:OU76gHeRo8xrzGJU3F3I1CqX1ekM8dfJw0+wPeMwnp0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
This commit switches the bufferpool to use the zeropool implementation for sync pools.

The stdlib sync.Pool implementation has an issue where it causes an additional heap allocation per Put() call when used with byte slices.

github.com/colega/zeropool package has been specifically designed to work around this issue, which reduces GC pressure and improves performance.

This also fixes the bufferpool's pkg benchmark to use a new pool per test, to avoid other tests influencing the behavior of the benchmark and sets it to report the allocations.