### PR TITLE
Refactor

### DIFF
--- a/allocator.go
+++ b/allocator.go
@@ -1,0 +1,275 @@
+package capnp
+
+import (
+	"errors"
+
+	"capnproto.org/go/capnp/v3/exp/bufferpool"
+)
+
+// allocator defines methods for an allocator for the basic arena
+// implementation: the allocator defines the strategy of how to grow and
+// release memory slices that back segments.
+type allocator interface {
+	// Grow an array. When called, it has already been determined that
+	// the slice must be grown. Implementations must copy the contents of
+	// the existing byte slice to the new one.
+	//
+	// The returned slice may be have a capacity larger than strcictly
+	// required to store an addition sz bytes. In this case, the length
+	// must be len(b)+sz, while cap may be any amount >= than that.
+	Grow(b []byte, totalMsgSize int64, sz Size) ([]byte, error)
+
+	// Release signals that the passed byte slice won't be used by the
+	// arena anymore.
+	Release(b []byte)
+}
+
+// bufferPoolAllocator allocates buffers from a buffer pool. If nil, then
+// the global default buffer pool is used.
+type bufferPoolAllocator bufferpool.Pool
+
+func (bpa *bufferPoolAllocator) Grow(b []byte, totalMsgSize int64, sz Size) ([]byte, error) {
+	pool := (*bufferpool.Pool)(bpa)
+	if pool == nil {
+		pool = &bufferpool.Default
+	}
+
+	inc, err := nextAlloc(totalMsgSize, int64(maxAllocSize()), sz)
+	if err != nil {
+		return nil, err
+	}
+	nb := pool.Get(len(b) + int(inc))
+
+	// When there was a prior buffer, copy the contents to the new buffer,
+	// clear the old buffer and return the old buffer to the pool to be
+	// reused.
+	if b != nil {
+		copy(nb[:cap(nb)], b[:cap(b)])
+		for i := range b {
+			b[i] = 0
+		}
+		pool.Put(b)
+	}
+
+	return nb, nil
+}
+
+func (bpa *bufferPoolAllocator) Release(b []byte) {
+	if b == nil {
+		panic("nil buffer passed to release")
+	}
+	pool := (*bufferpool.Pool)(bpa)
+	if pool == nil {
+		pool = &bufferpool.Default
+	}
+	pool.Put(b)
+}
+
+// simpleAllocator allocates buffers without any caching or reuse, using the
+// standard memory management functions.
+//
+// This allocator is concurent safe for use across multiple arenas.
+type simpleAllocator struct{}
+
+func (_ simpleAllocator) Grow(b []byte, totalMsgSize int64, sz Size) ([]byte, error) {
+	inc, err := nextAlloc(totalMsgSize, int64(maxAllocSize()), sz)
+	if err != nil {
+		return nil, err
+	}
+	return append(b, make([]byte, inc)...), nil
+}
+
+func (_ simpleAllocator) Release(b []byte) {
+	// Nothing to do. The runtime GC will reclaim it.
+}
+
+// segmentList defines the operations needed for a container of segments.
+type segmentList interface {
+	// NumSegments must return the number of segments that exist.
+	NumSegments() int
+
+	// SegmentFor returns a segment on which to store sz bytes. This may be
+	// a new or an existing segment.
+	SegmentFor(sz Size) (*Segment, error)
+
+	// Segment returns the specified segment. Returns nil if the segment
+	// does not exist.
+	Segment(id SegmentID) *Segment
+
+	// Reset clears the list of segments and sets all segments to point to
+	// a nil message and data slice.
+	Reset()
+}
+
+// singleSegmentList is a segment list that only stores a single segment.
+type singleSegmentList Segment
+
+func (ssl *singleSegmentList) NumSegments() int                    { return 1 }
+func (ssl *singleSegmentList) SegmentFor(_ Size) (*Segment, error) { return (*Segment)(ssl), nil }
+func (ssl *singleSegmentList) Reset() {
+	ssl.data = nil
+	ssl.msg = nil
+}
+func (ssl *singleSegmentList) Segment(id SegmentID) *Segment {
+	if id == 0 {
+		return (*Segment)(ssl)
+	}
+	return nil
+}
+
+// multiSegmentList is a segment list that stores segments in a byte slice.
+//
+// New segments are allocated if none of the existing segments has enough
+// capacity for new data.
+type multiSegmentList struct {
+	segs []Segment
+}
+
+func (msl *multiSegmentList) NumSegments() int {
+	return len(msl.segs)
+}
+
+func (msl *multiSegmentList) SegmentFor(sz Size) (*Segment, error) {
+	var seg *Segment
+	for i := range msl.segs {
+		if hasCapacity(msl.segs[i].data, sz) {
+			seg = &msl.segs[i]
+			break
+		}
+	}
+	if seg == nil {
+		i := len(msl.segs)
+		msl.segs = append(msl.segs, Segment{id: SegmentID(i)})
+		seg = &msl.segs[i]
+	}
+	return seg, nil
+}
+
+func (msl *multiSegmentList) Segment(id SegmentID) *Segment {
+	if int(id) < len(msl.segs) {
+		return &msl.segs[int(id)]
+	}
+	return nil
+}
+
+func (msl *multiSegmentList) Reset() {
+	for i := range msl.segs {
+		msl.segs[i].data = nil
+		msl.segs[i].msg = nil
+	}
+	msl.segs = msl.segs[:0]
+}
+
+// arena is an implementation of an Arena that offloads most of its work to an
+// associated allocator and segment list.
+type arena struct {
+	alloc allocator
+	segs  segmentList
+}
+
+func (a arena) Allocate(sz Size, msg *Message, seg *Segment) (*Segment, address, error) {
+	// Determine total allocated amount in the arena.
+	var total int64
+	for i := 0; i < a.segs.NumSegments(); i++ {
+		seg := a.segs.Segment(SegmentID(i))
+		if seg == nil {
+			return nil, 0, errors.New("segment out of bounds")
+		}
+
+		total += int64(len(seg.data))
+		if total < 0 {
+			return nil, 0, errors.New("overflow attempting to allocate")
+		}
+	}
+
+	// Determine the slice that will receive new data. Reuse seg if it has
+	// enough space for the data, otherwise ask the segment list for a
+	// segment to store data in (which may or may not be the same segment).
+	var b []byte
+	needsClearing := false
+	if seg == nil || !hasCapacity(seg.data, sz) {
+		var err error
+
+		// Determine the segment to allocate in.
+		seg, err = a.segs.SegmentFor(sz)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		b = seg.data
+		if !hasCapacity(b, sz) {
+			// Size or resize the data.
+			b, err = a.alloc.Grow(seg.data, total, sz)
+			if err != nil {
+				return nil, 0, err
+			}
+		} else {
+			needsClearing = true
+		}
+	} else {
+		b = seg.data
+		needsClearing = true
+	}
+
+	// The segment's full data is in b[0:], while the buffer requested by
+	// the caller is in b[<prior len of buffer>:]. When this was a new
+	// segment, the two will be the same.
+	//
+	// The starting address of the newly allocated space is the end of the
+	// prior data.
+	addr := address(len(seg.data))
+	seg.data = b[:addr.addSizeUnchecked(sz)]
+	seg.msg = msg
+
+	// Clear the data after addr to ensure it is zero. The allocators
+	// usually already return cleared data, but sometimes a buffer is
+	// explicitly passed with left over data, so this ensures the memory
+	// that is about to be used is in fact all zeroes.
+	if needsClearing {
+		// TODO: use clear() once go 1.21 is the minimum required
+		// version.
+		toClear := seg.data[addr:]
+		for i := range toClear {
+			toClear[i] = 0
+		}
+	}
+
+	return seg, addr, nil
+}
+
+func (a arena) Release() {
+	if a.alloc == nil && a.segs == nil {
+		// Empty arena. Use sane defaults.
+		a.alloc = (*bufferPoolAllocator)(nil)
+		a.segs = &singleSegmentList{}
+	}
+
+	for i := 0; i < a.segs.NumSegments(); i++ {
+		// Release segment data to the allocator.
+		seg := a.segs.Segment(SegmentID(i))
+		if seg.data != nil {
+			a.alloc.Release(seg.data)
+		}
+	}
+
+	// Reset list of segments.
+	a.segs.Reset()
+}
+
+// NumSegments returns the number of segments in the arena.
+func (a arena) NumSegments() int64 {
+	return int64(a.segs.NumSegments())
+}
+
+// Data returns the data in the given segment or an error.
+func (a arena) Data(id SegmentID) ([]byte, error) {
+	seg := a.segs.Segment(id)
+	if seg == nil {
+		return nil, errors.New("segment out of bounds")
+	}
+	return seg.data, nil
+}
+
+func (a arena) Segment(id SegmentID) *Segment {
+	return a.segs.Segment(id)
+}

--- a/arena.go
+++ b/arena.go
@@ -2,10 +2,8 @@ package capnp
 
 import (
 	"errors"
-	"sync"
 
-	"capnproto.org/go/capnp/v3/exp/bufferpool"
-	"capnproto.org/go/capnp/v3/internal/str"
+	"capnproto.org/go/capnp/v3/exc"
 )
 
 // An Arena loads and allocates segments for a Message.
@@ -17,24 +15,28 @@ type Arena interface {
 	// Data loads the data for the segment with the given ID.  IDs are in
 	// the range [0, NumSegments()).
 	// must be tightly packed in the range [0, NumSegments()).
+	//
+	// TODO: remove in favor of Segment(x).Data().
+	// Deprecated.
 	Data(id SegmentID) ([]byte, error)
+
+	// Segment returns the segment identified with the specified id. This
+	// may return nil if the segment with the specified ID does not exist.
+	Segment(id SegmentID) *Segment
 
 	// Allocate selects a segment to place a new object in, creating a
 	// segment or growing the capacity of a previously loaded segment if
 	// necessary.  If Allocate does not return an error, then the
 	// difference of the capacity and the length of the returned slice
-	// must be at least minsz.  segs is a map of segments keyed by ID
-	// using arrays returned by the Data method (although the length of
-	// these slices may have changed by previous allocations).  Allocate
-	// must not modify segs.
+	// must be at least minsz.  Some allocators may specifically choose
+	// to grow the passed seg (if non nil).
 	//
 	// If Allocate creates a new segment, the ID must be one larger than
 	// the last segment's ID or zero if it is the first segment.
 	//
 	// If Allocate returns an previously loaded segment's ID, then the
-	// arena is responsible for preserving the existing data in the
-	// returned byte slice.
-	Allocate(minsz Size, segs map[SegmentID]*Segment) (SegmentID, []byte, error)
+	// arena is responsible for preserving the existing data.
+	Allocate(sz Size, msg *Message, seg *Segment) (*Segment, address, error)
 
 	// Release all resources associated with the Arena. Callers MUST NOT
 	// use the Arena after it has been released.
@@ -51,194 +53,66 @@ type Arena interface {
 // in a continguous slice.  Allocation is performed by first allocating a
 // new slice and copying existing data. SingleSegment arena does not fail
 // unless the caller attempts to access another segment.
-type SingleSegmentArena []byte
-
-// SingleSegment constructs a SingleSegmentArena from b.  b MAY be nil.
-// Callers MAY use b to populate the segment for reading, or to reserve
-// memory of a specific size.
-func SingleSegment(b []byte) *SingleSegmentArena {
-	return (*SingleSegmentArena)(&b)
-}
-
-func (ssa SingleSegmentArena) NumSegments() int64 {
-	return 1
-}
-
-func (ssa SingleSegmentArena) Data(id SegmentID) ([]byte, error) {
-	if id != 0 {
-		return nil, errors.New("segment " + str.Utod(id) + " requested in single segment arena")
+func SingleSegment(b []byte) Arena {
+	var alloc allocator = (*bufferPoolAllocator)(nil)
+	if b != nil {
+		// When b is specified, do not return the buffer to any
+		// caches, because we don't know where the caller got the
+		// buffer from.
+		alloc = simpleAllocator{}
 	}
-	return ssa, nil
-}
-
-func (ssa *SingleSegmentArena) Allocate(sz Size, segs map[SegmentID]*Segment) (SegmentID, []byte, error) {
-	data := []byte(*ssa)
-	if segs[0] != nil {
-		data = segs[0].data
+	return arena{
+		alloc: alloc,
+		segs:  &singleSegmentList{data: b},
 	}
-	if len(data)%int(wordSize) != 0 {
-		return 0, nil, errors.New("segment size is not a multiple of word size")
-	}
-	if hasCapacity(data, sz) {
-		return 0, data, nil
-	}
-	inc, err := nextAlloc(int64(len(data)), int64(maxAllocSize()), sz)
-	if err != nil {
-		return 0, nil, err
-	}
-	buf := bufferpool.Default.Get(cap(data) + inc)
-	copied := copy(buf, data)
-	buf = buf[:copied]
-	bufferpool.Default.Put(data)
-	*ssa = buf
-	return 0, *ssa, nil
-}
-
-func (ssa SingleSegmentArena) String() string {
-	return "single-segment arena [len=" + str.Itod(len(ssa)) + " cap=" + str.Itod(cap(ssa)) + "]"
-}
-
-// Return this arena to an internal sync.Pool of arenas that can be
-// re-used. Any time SingleSegment(nil) is called, arenas from this
-// pool will be used if available, which can help reduce memory
-// allocations.
-//
-// All segments will be zeroed before re-use.
-//
-// Calling Release is optional; if not done the garbage collector
-// will release the memory per usual.
-func (ssa *SingleSegmentArena) Release() {
-	bufferpool.Default.Put(*ssa)
-	*ssa = nil
-}
-
-// MultiSegment is an arena that stores object data across multiple []byte
-// buffers, allocating new buffers of exponentially-increasing size when
-// full. This avoids the potentially-expensive slice copying of SingleSegment.
-type MultiSegmentArena struct {
-	ss    [][]byte
-	delim int    // index of first segment in ss that is NOT in buf
-	buf   []byte // full-sized buffer that was demuxed into ss.
 }
 
 // MultiSegment returns a new arena that allocates new segments when
 // they are full.  b MAY be nil.  Callers MAY use b to populate the
 // buffer for reading or to reserve memory of a specific size.
-func MultiSegment(b [][]byte) *MultiSegmentArena {
-	if b == nil {
-		return multiSegmentPool.Get().(*MultiSegmentArena)
-	}
-	return multiSegment(b)
-}
-
-// Return this arena to an internal sync.Pool of arenas that can be
-// re-used. Any time MultiSegment(nil) is called, arenas from this
-// pool will be used if available, which can help reduce memory
-// allocations.
-//
-// All segments will be zeroed before re-use.
-//
-// Calling Release is optional; if not done the garbage collector
-// will release the memory per usual.
-func (msa *MultiSegmentArena) Release() {
-	for i, v := range msa.ss {
-		msa.ss[i] = nil
-
-		// segment not in buf?
-		if i >= msa.delim {
-			bufferpool.Default.Put(v)
+func MultiSegment(b [][]byte) Arena {
+	var alloc allocator = (*bufferPoolAllocator)(nil)
+	var segs []Segment
+	if b != nil {
+		// When b is specified, do not return the buffer to any
+		// caches, because we don't know where the caller got the
+		// buffer from.
+		alloc = simpleAllocator{}
+		segs = make([]Segment, len(b))
+		for i := range b {
+			segs[i] = Segment{id: SegmentID(i), data: b[i]}
 		}
 	}
-
-	bufferpool.Default.Put(msa.buf) // nil is ok
-	*msa = MultiSegmentArena{ss: msa.ss[:0]}
-	multiSegmentPool.Put(msa)
+	return arena{
+		alloc: alloc,
+		segs:  &multiSegmentList{segs: segs},
+	}
 }
 
-// Like MultiSegment, but doesn't use the pool
-func multiSegment(b [][]byte) *MultiSegmentArena {
-	return &MultiSegmentArena{ss: b}
-}
-
-var multiSegmentPool = sync.Pool{
-	New: func() any {
-		return multiSegment(make([][]byte, 0, 16))
-	},
-}
-
-// demuxArena slices data into a multi-segment arena.  It assumes that
-// len(data) >= hdr.totalSize().
-func (msa *MultiSegmentArena) demux(hdr streamHeader, data []byte) error {
+// demuxArena demuxes a byte slice (that contains data for a list of
+// segments identified on the header) into an appropriate arena.
+func demuxArena(hdr streamHeader, data []byte) (Arena, error) {
 	maxSeg := hdr.maxSegment()
 	if int64(maxSeg) > int64(maxInt-1) {
-		return errors.New("number of segments overflows int")
+		return arena{}, errors.New("number of segments overflows int")
 	}
 
-	msa.buf = data
-	msa.delim = int(maxSeg + 1)
+	if maxSeg == 0 && len(data) == 0 {
+		return SingleSegment(nil), nil
+	}
 
-	// We might be forced to allocate here, but hopefully it won't
-	// happen to often.  We assume msa was freshly obtained from a
-	// pool, and that no segments have been allocated yet.
-	var segment []byte
-	for i := 0; i < msa.delim; i++ {
+	segBufs := make([][]byte, maxSeg+1)
+	off := 0
+	for i := range segBufs {
 		sz, err := hdr.segmentSize(SegmentID(i))
 		if err != nil {
-			return err
+			return arena{}, exc.WrapError("decode", err)
 		}
-
-		segment, data = data[:sz:sz], data[sz:]
-		msa.ss = append(msa.ss, segment)
+		segBufs[i] = data[off : off+int(sz)]
+		off += int(sz)
 	}
 
-	return nil
-}
-
-func (msa *MultiSegmentArena) NumSegments() int64 {
-	return int64(len(msa.ss))
-}
-
-func (msa *MultiSegmentArena) Data(id SegmentID) ([]byte, error) {
-	if int64(id) >= int64(len(msa.ss)) {
-		return nil, errors.New("segment " + str.Utod(id) + " requested (arena only has " +
-			str.Itod(len(msa.ss)) + " segments)")
-	}
-	return msa.ss[id], nil
-}
-
-func (msa *MultiSegmentArena) Allocate(sz Size, segs map[SegmentID]*Segment) (SegmentID, []byte, error) {
-	var total int64
-	for i, data := range msa.ss {
-		id := SegmentID(i)
-		if s := segs[id]; s != nil {
-			data = s.data
-		}
-
-		if hasCapacity(data, sz) {
-			return id, data, nil
-		}
-
-		if total += int64(cap(data)); total < 0 {
-			// Overflow.
-			return 0, nil, errors.New("alloc " + str.Utod(sz) + " bytes: message too large")
-		}
-	}
-
-	n, err := nextAlloc(total, 1<<63-1, sz)
-	if err != nil {
-		return 0, nil, err
-	}
-
-	buf := bufferpool.Default.Get(n)
-	buf = buf[:0]
-
-	id := SegmentID(len(msa.ss))
-	msa.ss = append(msa.ss, buf)
-	return id, buf, nil
-}
-
-func (msa *MultiSegmentArena) String() string {
-	return "multi-segment arena [" + str.Itod(len(msa.ss)) + " segments]"
+	return MultiSegment(segBufs), nil
 }
 
 // nextAlloc computes how much more space to allocate given the number
@@ -286,4 +160,41 @@ func nextAlloc(curr, max int64, req Size) (int, error) {
 
 func hasCapacity(b []byte, sz Size) bool {
 	return sz <= Size(cap(b)-len(b))
+}
+
+// ReadOnlySingleSegmentArena is a single segment arena backed by a byte slice
+// that does not allow allocations.
+type ReadOnlySingleSegmentArena Segment
+
+func (a *ReadOnlySingleSegmentArena) NumSegments() int64 {
+	return 1
+}
+
+func (a *ReadOnlySingleSegmentArena) Data(id SegmentID) ([]byte, error) {
+	if id != 0 {
+		return nil, errors.New("segment out of bounds")
+	}
+	return a.data, nil
+}
+
+// Segment returns the segment identified with the specified id. This
+// may return nil if the segment with the specified ID does not exist.
+func (a *ReadOnlySingleSegmentArena) Segment(id SegmentID) *Segment {
+	if id > 0 {
+		return nil
+	}
+	return (*Segment)(a)
+}
+
+func (a *ReadOnlySingleSegmentArena) Allocate(sz Size, msg *Message, seg *Segment) (*Segment, address, error) {
+	return nil, 0, errors.New("ReadOnlySingleSegmentArena cannot allocate")
+}
+
+func (a *ReadOnlySingleSegmentArena) Release() {
+	// This does nothing.
+}
+
+// UseBuffer switches the internal buffer to use the specified one.
+func (a *ReadOnlySingleSegmentArena) UseBuffer(b []byte) {
+	a.data = b
 }

--- a/arena_test.go
+++ b/arena_test.go
@@ -50,6 +50,7 @@ func TestSingleSegment(t *testing.T) {
 	})
 }
 
+/*
 func TestSingleSegmentAllocate(t *testing.T) {
 	t.Parallel()
 
@@ -118,6 +119,7 @@ func TestSingleSegmentAllocate(t *testing.T) {
 		tests[i].run(t, i)
 	}
 }
+*/
 
 func TestMultiSegment(t *testing.T) {
 	t.Parallel()
@@ -163,6 +165,8 @@ func TestMultiSegment(t *testing.T) {
 		}
 	})
 }
+
+/*
 
 func TestMultiSegmentAllocate(t *testing.T) {
 	t.Parallel()
@@ -233,3 +237,4 @@ func TestMultiSegmentAllocate(t *testing.T) {
 		tests[i].run(t, i)
 	}
 }
+*/

--- a/canonical.go
+++ b/canonical.go
@@ -18,7 +18,7 @@ func Canonicalize(s Struct) ([]byte, error) {
 	if err != nil {
 		return nil, exc.WrapError("canonicalize", err)
 	}
-	if err := msg.SetRoot(root.ToPtr()); err != nil {
+	if err := msg.SetRoot(root.ToPtr()); err != nil { // TODO: dupe from NewRootStruct?
 		return nil, exc.WrapError("canonicalize", err)
 	}
 	if err := fillCanonicalStruct(root, s); err != nil {

--- a/exp/bufferpool/pool_test.go
+++ b/exp/bufferpool/pool_test.go
@@ -68,8 +68,17 @@ func TestPut(t *testing.T) {
 }
 
 func BenchmarkPool(b *testing.B) {
+	var pool bufferpool.Pool
+	const size = 32
+
+	// Make cache hot.
+	buf := pool.Get(size)
+	pool.Put(buf)
+
+	b.ResetTimer()
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		buf := bufferpool.Default.Get(32)
-		bufferpool.Default.Put(buf)
+		buf := pool.Get(size)
+		pool.Put(buf)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module capnproto.org/go/capnp/v3
 go 1.19
 
 require (
+	github.com/colega/zeropool v0.0.0-20230505084239-6fb4a4f75381
 	github.com/kylelemons/godebug v1.1.0
 	github.com/stretchr/testify v1.8.2
 	github.com/tinylib/msgp v1.1.5

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/colega/zeropool v0.0.0-20230505084239-6fb4a4f75381 h1:d5EKgQfRQvO97jnISfR89AiCCCJMwMFoSxUiU0OGCRU=
+github.com/colega/zeropool v0.0.0-20230505084239-6fb4a4f75381/go.mod h1:OU76gHeRo8xrzGJU3F3I1CqX1ekM8dfJw0+wPeMwnp0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/integration_test.go
+++ b/integration_test.go
@@ -1779,7 +1779,10 @@ func BenchmarkUnmarshal_Reuse(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		*ta = testArena(data[r.Intn(len(data))][8:])
-		msg.Reset(arena)
+		_, err := msg.Reset(arena)
+		if err != nil {
+			b.Fatal(err)
+		}
 		a, _ := air.ReadRootBenchmarkA(msg)
 		unmarshalA(a)
 	}

--- a/message_test.go
+++ b/message_test.go
@@ -661,3 +661,17 @@ func BenchmarkMessageGetFirstSegment(b *testing.B) {
 		}
 	}
 }
+
+// TestCannotResetArenaForRead demonstrates that Reset() cannot be used when
+// intending to read data from an arena (i.e. cannot reuse a msg value by
+// calling Reset with the intention to read data).
+func TestCannotResetArenaForRead(t *testing.T) {
+	var msg Message
+	var arena Arena = SingleSegment(incrementingData(8))
+
+	_, err := msg.Reset(arena)
+	if err == nil {
+		t.Fatal("expected non nil error, got nil")
+	}
+	t.Logf("Got err: %v", err)
+}

--- a/message_test.go
+++ b/message_test.go
@@ -643,3 +643,21 @@ func (readOnlyArena) Allocate(sz Size, segs map[SegmentID]*Segment) (SegmentID, 
 }
 
 var errReadOnlyArena = errors.New("Allocate called on read-only arena")
+
+func BenchmarkMessageGetFirstSegment(b *testing.B) {
+	var msg Message
+	var arena Arena = SingleSegment(nil)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := msg.Reset(arena)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_, err = msg.Segment(0)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/message_test.go
+++ b/message_test.go
@@ -604,8 +604,9 @@ type arenaAllocTest struct {
 }
 
 func (test *arenaAllocTest) run(t *testing.T, i int) {
-	arena, segs := test.init()
-	id, data, err := arena.Allocate(test.size, segs)
+	arena, _ := test.init()
+	seg, _, err := arena.Allocate(test.size, nil, nil)
+	id, data := seg.id, seg.data
 
 	if err != nil {
 		t.Errorf("tests[%d] - %s: Allocate error: %v", i, test.name, err)
@@ -638,8 +639,8 @@ func (ro readOnlyArena) String() string {
 	return fmt.Sprintf("readOnlyArena{%v}", ro.Arena)
 }
 
-func (readOnlyArena) Allocate(sz Size, segs map[SegmentID]*Segment) (SegmentID, []byte, error) {
-	return 0, nil, errReadOnlyArena
+func (readOnlyArena) Allocate(sz Size, msg *Message, seg *Segment) (*Segment, address, error) {
+	return nil, 0, errReadOnlyArena
 }
 
 var errReadOnlyArena = errors.New("Allocate called on read-only arena")

--- a/rpc/senderpromise_test.go
+++ b/rpc/senderpromise_test.go
@@ -354,6 +354,7 @@ func TestDisembargoSenderPromise(t *testing.T) {
 // Tests that E-order is respected when fulfilling a promise with something on
 // the remote peer.
 func TestPromiseOrdering(t *testing.T) {
+	t.Skip("Disabled due to being flaky")
 	t.Parallel()
 
 	ctx := context.Background()

--- a/segment.go
+++ b/segment.go
@@ -15,6 +15,8 @@ type SegmentID uint32
 // It is part of a Message, which can contain other segments that
 // reference each other.
 type Segment struct {
+	// msg associated with this segment. A Message instance m maintains the
+	// invariant that that all m.segs[].msg == m.
 	msg  *Message
 	id   SegmentID
 	data []byte


### PR DESCRIPTION
Requires #555, #556

Elided tests and creating as draft to get a first pass review.

The diff is large(ish) so it may be easier to read the full code vs the diff at the moment. But the basic idea of the refactor is the following:

#### Split allocator strategy and segment management

Using the bufferpool should not be forced upon the caller. And in fact, it is dangerous to use the current implementation of single/multi segment arenas if you send a buffer allocated from anywhere _not_ there. For example, an mmaped file buffer.

Spinning the allocator into its own thing means we can define different allocation strategies (bufferpool, regular runtime functions, simpler caching strategy, read-only, etc).

Unfortunately, due to some tests failing otherwise, I couldn't unify literally everything inside the allocator (see further below for discussion).

#### Base arena implementation

SingleSegment and MultiSegment arenas have been unified into a single arena impl that offloads the logic to the allocator and segment list.

So the full matrix of Single/Multi and BufferPool/runtime-backed options can be exercised.

#### Reduce message complexiy

Most decisions have been offloaded from message into the arena, segment list or allocator. This makes `Message` more generic and easier to reason about: in particular, it no longer cares how many segments there are during init (see further below for discussion on Release) and the roundabound way it used to initialize the first segment.

#### Test compatibility and issues

All the existing tests pass. A few that are no longer applicable (dealing with the concrete arena implementations) have been commented out. One test (`TestPromiseOrdering`) is skipped because it's flaky even in the current main branch.

Other than those, the code has been specifically designed to not require changes in the existing tests, and therefore should be ensuring full compatibility to the existing code.

Tests for the new features haven't been done yet (but will if this is deemed to be in the right direction).

#### Message.Release is full of special cases

One main source of frustration during this rewrite is that `Message.Release` is full of special cases, mostly to deal with initializing a message for writing. It has all these cases I had to add to avoid having to touch the existing tests. These special cases are documented now in the code, after a `FIXME(matheusd)` line in that function.

Personally, I think my `ReleaseForRead()` should be the actual implementation of `Release`, but in the interest of not breaking client code, I opted for adding a new function instead.

This is also somewhat the reason for having to add a `ReadOnlySingleSegmentArena` instead of using a read only allocator: Release() is (currently) expected to check the arena is clear and re-allocate the first segment (i.e. "Prove Reset() cannot be used to reset a read-only message" commit), so I had to go out of my way to create an arena that would make it easier to just read only, while reusing the message struct.


