### PR TITLE
ci: update github actions to latest versions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.19', '1.20' ]
+        go: [ '1.21', '1.22' ]
         arch: [ 'amd64', '386' ]
     name: Go ${{ matrix.go }} GOARCH=${{ matrix.arch }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
       - name: Set GOARCH


### PR DESCRIPTION
- Upgrade actions/checkout to v4
- Upgrade actions/setup-go to v5
- Update go-versions to be `1.21` and `1.22` (two most recent versions)