### PR TITLE
rpc: Start fixing TestPromiseOrdering

### DIFF
--- a/rpc/localpromise_test.go
+++ b/rpc/localpromise_test.go
@@ -11,12 +11,15 @@ import (
 )
 
 type echoNumOrderChecker struct {
-	t       *testing.T
-	nextNum int64
+	t             *testing.T
+	nextNum       int64
+	skipAssertNum bool
 }
 
 func (e *echoNumOrderChecker) EchoNum(ctx context.Context, p testcapnp.PingPong_echoNum) error {
-	assert.Equal(e.t, e.nextNum, p.Args().N())
+	if !e.skipAssertNum {
+		assert.Equal(e.t, e.nextNum, p.Args().N())
+	}
 	e.nextNum++
 	results, err := p.AllocResults()
 	if err != nil {

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -322,10 +322,10 @@ func (c *Conn) Bootstrap(ctx context.Context) (bc capnp.Client) {
 
 		q := c.newQuestion(capnp.Method{})
 		bc = q.p.Answer().Client().AddRef()
-		go func() {
+		bc.AttachReleaser(func() {
 			q.p.ReleaseClients()
 			q.release()
-		}()
+		})
 
 		c.sendMessage(ctx, func(m rpccp.Message) error {
 			boot, err := m.NewBootstrap()


### PR DESCRIPTION
First part of the fix to `TestPromiseOrdering`.

This has been discussed in the matrix channel and a full explanation of the underlying issue and fixes can be found [in this blog post](https://matheusd.com/preview/fixing-gocapnp-promise-err/),