### PR TITLE
CI: Reduce number of test runs of rpc

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,4 +32,4 @@ jobs:
         run: |
           cd rpc
           go test -c
-          for i in `seq 500`; do ./rpc.test; done
+          for i in `seq 50`; do ./rpc.test; done


### PR DESCRIPTION
This reduces the number of sequential tests of the RPC subsystem from
500 to 50. This speeds up the run of the CI and reduces flakiness.
