### PR TITLE
capnp: Refactor Arenas

### DIFF
--- a/arena.go
+++ b/arena.go
@@ -14,27 +14,32 @@ type Arena interface {
 	// This must not be larger than 1<<32.
 	NumSegments() int64
 
+	// Segment returns the segment identified with the specified id. This
+	// may return nil if the segment with the specified ID does not exist.
+	Segment(id SegmentID) *Segment
+
 	// Data loads the data for the segment with the given ID.  IDs are in
 	// the range [0, NumSegments()).
 	// must be tightly packed in the range [0, NumSegments()).
+	//
+	// Deprecated. Use .Segment(id).Data().
 	Data(id SegmentID) ([]byte, error)
 
 	// Allocate selects a segment to place a new object in, creating a
 	// segment or growing the capacity of a previously loaded segment if
-	// necessary.  If Allocate does not return an error, then the
-	// difference of the capacity and the length of the returned slice
-	// must be at least minsz.  segs is a map of segments keyed by ID
-	// using arrays returned by the Data method (although the length of
-	// these slices may have changed by previous allocations).  Allocate
-	// must not modify segs.
+	// necessary.  If Allocate does not return an error, then the returned
+	// segment may store up to minsz bytes starting at the returned address
+	// offset.
+	//
+	// Some allocators may specifically choose to grow the passed seg (if
+	// non nil), but that is not a requirement.
 	//
 	// If Allocate creates a new segment, the ID must be one larger than
 	// the last segment's ID or zero if it is the first segment.
 	//
-	// If Allocate returns an previously loaded segment's ID, then the
-	// arena is responsible for preserving the existing data in the
-	// returned byte slice.
-	Allocate(minsz Size, segs map[SegmentID]*Segment) (SegmentID, []byte, error)
+	// If Allocate returns an previously loaded segment, then the arena is
+	// responsible for preserving the existing data.
+	Allocate(minsz Size, msg *Message, seg *Segment) (*Segment, address, error)
 
 	// Release all resources associated with the Arena. Callers MUST NOT
 	// use the Arena after it has been released.
@@ -47,55 +52,94 @@ type Arena interface {
 	Release()
 }
 
+// singleSegmentPool is a pool of *SingleSegmentArena.
+var singleSegmentPool = sync.Pool{
+	New: func() any {
+		return &SingleSegmentArena{}
+	},
+}
+
 // SingleSegmentArena is an Arena implementation that stores message data
 // in a continguous slice.  Allocation is performed by first allocating a
 // new slice and copying existing data. SingleSegment arena does not fail
 // unless the caller attempts to access another segment.
-type SingleSegmentArena []byte
+type SingleSegmentArena struct {
+	seg Segment
+
+	// bp is the bufferpool assotiated with this arena if it was initialized
+	// for writing.
+	bp *bufferpool.Pool
+
+	// fromPool determines if this should return to the pool when released.
+	fromPool bool
+}
+
+func zeroSlice(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}
 
 // SingleSegment constructs a SingleSegmentArena from b.  b MAY be nil.
 // Callers MAY use b to populate the segment for reading, or to reserve
 // memory of a specific size.
-func SingleSegment(b []byte) *SingleSegmentArena {
-	return (*SingleSegmentArena)(&b)
+func SingleSegment(b []byte) Arena {
+	if b == nil {
+		ssa := singleSegmentPool.Get().(*SingleSegmentArena)
+		ssa.fromPool = true
+		ssa.bp = &bufferpool.Default
+		return ssa
+	}
+
+	return &SingleSegmentArena{seg: Segment{data: b}}
 }
 
-func (ssa SingleSegmentArena) NumSegments() int64 {
+func (ssa *SingleSegmentArena) NumSegments() int64 {
 	return 1
 }
 
-func (ssa SingleSegmentArena) Data(id SegmentID) ([]byte, error) {
+func (ssa *SingleSegmentArena) Data(id SegmentID) ([]byte, error) {
 	if id != 0 {
 		return nil, errors.New("segment " + str.Utod(id) + " requested in single segment arena")
 	}
-	return ssa, nil
+	return ssa.seg.data, nil
 }
 
-func (ssa *SingleSegmentArena) Allocate(sz Size, segs map[SegmentID]*Segment) (SegmentID, []byte, error) {
-	data := []byte(*ssa)
-	if segs[0] != nil {
-		data = segs[0].data
+func (ssa *SingleSegmentArena) Segment(id SegmentID) *Segment {
+	return &ssa.seg
+}
+
+func (ssa *SingleSegmentArena) Allocate(sz Size, msg *Message, seg *Segment) (*Segment, address, error) {
+	if seg != nil && seg != &ssa.seg {
+		return nil, 0, errors.New("segment is not associated with arena")
 	}
+	data := ssa.seg.data
 	if len(data)%int(wordSize) != 0 {
-		return 0, nil, errors.New("segment size is not a multiple of word size")
+		return nil, 0, errors.New("segment size is not a multiple of word size")
 	}
+	ssa.seg.msg = msg
 	if hasCapacity(data, sz) {
-		return 0, data, nil
+		addr := address(len(ssa.seg.data))
+		ssa.seg.data = ssa.seg.data[:len(ssa.seg.data)+int(sz)]
+		return &ssa.seg, addr, nil
 	}
 	inc, err := nextAlloc(int64(len(data)), int64(maxAllocSize()), sz)
 	if err != nil {
-		return 0, nil, err
+		return nil, 0, err
 	}
-	buf := bufferpool.Default.Get(cap(data) + inc)
-	copied := copy(buf, data)
-	buf = buf[:copied]
-	bufferpool.Default.Put(data)
-	*ssa = buf
-	return 0, *ssa, nil
+	if ssa.bp == nil {
+		return nil, 0, errors.New("cannot allocate on read-only SingleSegmentArena")
+	}
+	addr := address(len(ssa.seg.data))
+	ssa.seg.data = ssa.bp.Get(cap(data) + inc)[:len(data)+int(sz)]
+	copy(ssa.seg.data, data)
+	zeroSlice(data)
+	ssa.bp.Put(data)
+	return &ssa.seg, addr, nil
 }
 
-func (ssa SingleSegmentArena) String() string {
-	return "single-segment arena [len=" + str.Itod(len(ssa)) + " cap=" + str.Itod(cap(ssa)) + "]"
+func (ssa *SingleSegmentArena) String() string {
+	return "single-segment arena [len=" + str.Itod(len(ssa.seg.data)) + " cap=" + str.Itod(cap(ssa.seg.data)) + "]"
 }
 
 // Return this arena to an internal sync.Pool of arenas that can be
@@ -108,17 +152,31 @@ func (ssa SingleSegmentArena) String() string {
 // Calling Release is optional; if not done the garbage collector
 // will release the memory per usual.
 func (ssa *SingleSegmentArena) Release() {
-	bufferpool.Default.Put(*ssa)
-	*ssa = nil
+	if ssa.bp != nil {
+		zeroSlice(ssa.seg.data)
+		ssa.bp.Put(ssa.seg.data)
+	}
+	ssa.seg.msg = nil
+	ssa.seg.data = nil
+	if ssa.fromPool {
+		ssa.fromPool = false // Prevent double return
+		singleSegmentPool.Put(ssa)
+	}
 }
 
 // MultiSegment is an arena that stores object data across multiple []byte
 // buffers, allocating new buffers of exponentially-increasing size when
 // full. This avoids the potentially-expensive slice copying of SingleSegment.
 type MultiSegmentArena struct {
-	ss    [][]byte
-	delim int    // index of first segment in ss that is NOT in buf
-	buf   []byte // full-sized buffer that was demuxed into ss.
+	segs []Segment
+
+	// bp is the bufferpool assotiated with this arena's segments if it was
+	// initialized for writing.
+	bp *bufferpool.Pool
+
+	// fromPool is true if this msa instance was obtained from the
+	// multiSegmentPool and should be returned there upon release.
+	fromPool bool
 }
 
 // MultiSegment returns a new arena that allocates new segments when
@@ -126,7 +184,9 @@ type MultiSegmentArena struct {
 // buffer for reading or to reserve memory of a specific size.
 func MultiSegment(b [][]byte) *MultiSegmentArena {
 	if b == nil {
-		return multiSegmentPool.Get().(*MultiSegmentArena)
+		msa := multiSegmentPool.Get().(*MultiSegmentArena)
+		msa.fromPool = true
+		return msa
 	}
 	return multiSegment(b)
 }
@@ -141,28 +201,47 @@ func MultiSegment(b [][]byte) *MultiSegmentArena {
 // Calling Release is optional; if not done the garbage collector
 // will release the memory per usual.
 func (msa *MultiSegmentArena) Release() {
-	for i, v := range msa.ss {
-		msa.ss[i] = nil
-
-		// segment not in buf?
-		if i >= msa.delim {
-			bufferpool.Default.Put(v)
+	for i := range msa.segs {
+		if msa.bp != nil {
+			zeroSlice(msa.segs[i].data)
+			msa.bp.Put(msa.segs[i].data)
 		}
+		msa.segs[i].data = nil
+		msa.segs[i].msg = nil
 	}
 
-	bufferpool.Default.Put(msa.buf) // nil is ok
-	*msa = MultiSegmentArena{ss: msa.ss[:0]}
-	multiSegmentPool.Put(msa)
+	if msa.segs != nil {
+		msa.segs = msa.segs[:0]
+	}
+
+	if msa.fromPool {
+		// Prevent double inclusion if it is used after release.
+		msa.fromPool = false
+
+		multiSegmentPool.Put(msa)
+	}
 }
 
 // Like MultiSegment, but doesn't use the pool
 func multiSegment(b [][]byte) *MultiSegmentArena {
-	return &MultiSegmentArena{ss: b}
+	var bp *bufferpool.Pool
+	var segs []Segment
+	if b == nil {
+		bp = &bufferpool.Default
+		segs = make([]Segment, 0, 5) // Typical size.
+	} else {
+		segs = make([]Segment, len(b))
+		for i := range b {
+			segs[i].data = b[i]
+			segs[i].id = SegmentID(i)
+		}
+	}
+	return &MultiSegmentArena{segs: segs, bp: bp}
 }
 
 var multiSegmentPool = sync.Pool{
 	New: func() any {
-		return multiSegment(make([][]byte, 0, 16))
+		return multiSegment(nil)
 	},
 }
 
@@ -174,71 +253,130 @@ func (msa *MultiSegmentArena) demux(hdr streamHeader, data []byte) error {
 		return errors.New("number of segments overflows int")
 	}
 
-	msa.buf = data
-	msa.delim = int(maxSeg + 1)
+	// Grow list of existing segments as needed.
+	numSegs := int(maxSeg + 1)
+	if cap(msa.segs) >= numSegs {
+		msa.segs = msa.segs[:numSegs]
+	} else {
+		inc := numSegs - len(msa.segs)
+		msa.segs = append(msa.segs, make([]Segment, inc)...)
+	}
 
-	// We might be forced to allocate here, but hopefully it won't
-	// happen to often.  We assume msa was freshly obtained from a
-	// pool, and that no segments have been allocated yet.
-	var segment []byte
-	for i := 0; i < msa.delim; i++ {
+	for i := SegmentID(0); i <= maxSeg; i++ {
 		sz, err := hdr.segmentSize(SegmentID(i))
 		if err != nil {
 			return err
 		}
 
-		segment, data = data[:sz:sz], data[sz:]
-		msa.ss = append(msa.ss, segment)
+		msa.segs[i].data, data = data[:sz:sz], data[sz:]
+		msa.segs[i].id = i
 	}
 
 	return nil
 }
 
 func (msa *MultiSegmentArena) NumSegments() int64 {
-	return int64(len(msa.ss))
+	return int64(len(msa.segs))
 }
 
 func (msa *MultiSegmentArena) Data(id SegmentID) ([]byte, error) {
-	if int64(id) >= int64(len(msa.ss)) {
+	if int64(id) >= int64(len(msa.segs)) {
 		return nil, errors.New("segment " + str.Utod(id) + " requested (arena only has " +
-			str.Itod(len(msa.ss)) + " segments)")
+			str.Itod(len(msa.segs)) + " segments)")
 	}
-	return msa.ss[id], nil
+	return msa.segs[id].data, nil
 }
 
-func (msa *MultiSegmentArena) Allocate(sz Size, segs map[SegmentID]*Segment) (SegmentID, []byte, error) {
-	var total int64
-	for i, data := range msa.ss {
-		id := SegmentID(i)
-		if s := segs[id]; s != nil {
-			data = s.data
+func (msa *MultiSegmentArena) Segment(id SegmentID) *Segment {
+	return &msa.segs[id]
+}
+
+func (msa *MultiSegmentArena) Allocate(sz Size, msg *Message, seg *Segment) (*Segment, address, error) {
+	// Prefer allocating in seg if it has capacity.
+	if seg != nil && hasCapacity(seg.data, sz) {
+		// Double check this segment is part of this arena.
+		contains := false
+		for i := range msa.segs {
+			if &msa.segs[i] == seg {
+				contains = true
+				break
+			}
 		}
 
+		if !contains {
+			// This is a usage error.
+			return nil, 0, errors.New("preferred segment is not part of the arena")
+		}
+
+		// Double check this segment is for this message.
+		if seg.msg != nil && seg.msg != msg {
+			return nil, 0, errors.New("attempt to allocate in segment for different message")
+		}
+
+		addr := address(len(seg.data))
+		newLen := int(addr) + int(sz)
+		seg.data = seg.data[:newLen]
+		seg.msg = msg
+		return seg, addr, nil
+	}
+
+	var total int64
+	for i := range msa.segs {
+		data := msa.segs[i].data
 		if hasCapacity(data, sz) {
-			return id, data, nil
+			// Found segment with spare capacity.
+			addr := address(len(msa.segs[i].data))
+			newLen := int(addr) + int(sz)
+			msa.segs[i].data = msa.segs[i].data[:newLen]
+			msa.segs[i].msg = msg
+			return &msa.segs[i], addr, nil
 		}
 
 		if total += int64(cap(data)); total < 0 {
 			// Overflow.
-			return 0, nil, errors.New("alloc " + str.Utod(sz) + " bytes: message too large")
+			return nil, 0, errors.New("alloc " + str.Utod(sz) + " bytes: message too large")
 		}
 	}
 
-	n, err := nextAlloc(total, 1<<63-1, sz)
-	if err != nil {
-		return 0, nil, err
+	// Check for read-only arena.
+	if msa.bp == nil {
+		return nil, 0, errors.New("cannot allocate segment in read-only multi-segment arena")
 	}
 
-	buf := bufferpool.Default.Get(n)
-	buf = buf[:0]
+	// If this is the very first segment and the requested allocation
+	// size is zero, modify the requested size to at least one word.
+	//
+	// FIXME: this is to maintain compatibility to existing behavior and
+	// tests in NewMessage(), which assumes this. Remove once arenas
+	// enforce the contract of always having at least one segment.
+	compatFirstSegLenZeroAddSize := Size(0)
+	if len(msa.segs) == 0 && sz == 0 {
+		compatFirstSegLenZeroAddSize = wordSize
+	}
 
-	id := SegmentID(len(msa.ss))
-	msa.ss = append(msa.ss, buf)
-	return id, buf, nil
+	// Determine actual allocation size (may be greater than sz).
+	n, err := nextAlloc(total, 1<<63-1, sz+compatFirstSegLenZeroAddSize)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// We have determined this will be a new segment. Get the backing
+	// buffer for it.
+	buf := msa.bp.Get(n)
+	buf = buf[:sz]
+
+	// Setup the segment.
+	id := SegmentID(len(msa.segs))
+	msa.segs = append(msa.segs, Segment{
+		data: buf,
+		id:   id,
+		msg:  msg,
+	})
+	return &msa.segs[int(id)], 0, nil
 }
 
 func (msa *MultiSegmentArena) String() string {
-	return "multi-segment arena [" + str.Itod(len(msa.ss)) + " segments]"
+	return "multi-segment arena [" + str.Itod(len(msa.segs)) + " segments]"
 }
 
 // nextAlloc computes how much more space to allocate given the number
@@ -286,4 +424,78 @@ func nextAlloc(curr, max int64, req Size) (int, error) {
 
 func hasCapacity(b []byte, sz Size) bool {
 	return sz <= Size(cap(b)-len(b))
+}
+
+type ReadOnlySingleSegment struct {
+	seg Segment
+}
+
+// NumSegments returns the number of segments in the arena.
+// This must not be larger than 1<<32.
+func (r *ReadOnlySingleSegment) NumSegments() int64 {
+	return 1
+}
+
+// Segment returns the segment identified with the specified id. This
+// may return nil if the segment with the specified ID does not exist.
+func (r *ReadOnlySingleSegment) Segment(id SegmentID) *Segment {
+	if id == 0 {
+		return &r.seg
+	}
+
+	return nil
+}
+
+// Data loads the data for the segment with the given ID.  IDs are in
+// the range [0, NumSegments()).
+// must be tightly packed in the range [0, NumSegments()).
+//
+// Deprecated. Use .Segment(id).Data().
+func (r *ReadOnlySingleSegment) Data(id SegmentID) ([]byte, error) {
+	if id == 0 {
+		return r.seg.data, nil
+	}
+	return nil, errors.New("segment does not exist")
+}
+
+// Allocate selects a segment to place a new object in, creating a
+// segment or growing the capacity of a previously loaded segment if
+// necessary.  If Allocate does not return an error, then the
+// difference of the capacity and the length of the returned slice
+// must be at least minsz.  Some allocators may specifically choose to
+// grow the passed seg (if non nil).
+//
+// If Allocate creates a new segment, the ID must be one larger than
+// the last segment's ID or zero if it is the first segment.
+//
+// If Allocate returns an previously loaded segment, then the
+// arena is responsible for preserving the existing data.
+func (r *ReadOnlySingleSegment) Allocate(minsz Size, msg *Message, seg *Segment) (*Segment, address, error) {
+	return nil, 0, errors.New("readOnly segment cannot allocate data")
+}
+
+// Release all resources associated with the Arena. Callers MUST NOT
+// use the Arena after it has been released.
+//
+// Calling Release() is OPTIONAL, but may reduce allocations.
+//
+// Implementations MAY use Release() as a signal to return resources
+// to free lists, or otherwise reuse the Arena.   However, they MUST
+// NOT assume Release() will be called.
+func (r *ReadOnlySingleSegment) Release() {
+	r.seg.data = nil
+}
+
+// ReplaceData replaces the current data of the arena. This should ONLY be
+// called on an empty or released arena, or else it panics.
+func (r *ReadOnlySingleSegment) ReplaceData(b []byte) {
+	if r.seg.data != nil {
+		panic("replacing data on unreleased ReadOnlyArena")
+	}
+
+	r.seg.data = b
+}
+
+func NewReadOnlySingleSegment(b []byte) *ReadOnlySingleSegment {
+	return &ReadOnlySingleSegment{seg: Segment{data: b}}
 }

--- a/arena_test.go
+++ b/arena_test.go
@@ -1,8 +1,6 @@
 package capnp
 
 import (
-	"bytes"
-	"errors"
 	"testing"
 
 	"capnproto.org/go/capnp/v3/exp/bufferpool"
@@ -47,13 +45,13 @@ func incrementingData(n int) []byte {
 	return b
 }
 
-func segmentData(a Arena, id SegmentID) ([]byte, error) {
+func segmentData(a Arena, id SegmentID) []byte {
 	seg := a.Segment(id)
 	if seg == nil {
-		return nil, errors.New("segment does not exist")
+		return nil
 	}
 
-	return seg.Data(), nil
+	return seg.Data()
 }
 
 func TestSingleSegment(t *testing.T) {
@@ -64,40 +62,22 @@ func TestSingleSegment(t *testing.T) {
 		t.Parallel()
 
 		arena := SingleSegment(nil)
-		if n := arena.NumSegments(); n != 1 {
-			t.Errorf("SingleSegment(nil).NumSegments() = %d; want 1", n)
-		}
-		data, err := segmentData(arena, 0)
-		if len(data) != 0 {
-			t.Errorf("SingleSegment(nil).Data(0) = %#v; want nil", data)
-		}
-		if err != nil {
-			t.Errorf("SingleSegment(nil).Data(0) error: %v", err)
-		}
-		_, err = segmentData(arena, 1)
-		if err == nil {
-			t.Error("SingleSegment(nil).Data(1) succeeded; want error")
-		}
+		require.Equal(t, int64(1), arena.NumSegments())
+		data0 := segmentData(arena, 0)
+		require.Empty(t, data0)
+		data1 := segmentData(arena, 1)
+		require.Empty(t, data1)
 	})
 
 	t.Run("ExistingData", func(t *testing.T) {
 		t.Parallel()
 
 		arena := SingleSegment(incrementingData(8))
-		if n := arena.NumSegments(); n != 1 {
-			t.Errorf("SingleSegment(incrementingData(8)).NumSegments() = %d; want 1", n)
-		}
-		data, err := segmentData(arena, 0)
-		if want := incrementingData(8); !bytes.Equal(data, want) {
-			t.Errorf("SingleSegment(incrementingData(8)).Data(0) = %#v; want %#v", data, want)
-		}
-		if err != nil {
-			t.Errorf("SingleSegment(incrementingData(8)).Data(0) error: %v", err)
-		}
-		_, err = segmentData(arena, 1)
-		if err == nil {
-			t.Error("SingleSegment(incrementingData(8)).Data(1) succeeded; want error")
-		}
+		require.Equal(t, int64(1), arena.NumSegments())
+		data0 := segmentData(arena, 0)
+		require.Equal(t, incrementingData(8), data0)
+		data1 := segmentData(arena, 1)
+		require.Empty(t, data1)
 	})
 }
 
@@ -179,40 +159,22 @@ func TestMultiSegment(t *testing.T) {
 		t.Parallel()
 
 		arena := MultiSegment(nil)
-		if n := arena.NumSegments(); n != 0 {
-			t.Errorf("MultiSegment(nil).NumSegments() = %d; want 1", n)
-		}
-		_, err := segmentData(arena, 0)
-		if err == nil {
-			t.Error("MultiSegment(nil).Data(0) succeeded; want error")
-		}
+		require.Equal(t, int64(0), arena.NumSegments())
+		data0 := segmentData(arena, 0)
+		require.Empty(t, data0)
 	})
 
 	t.Run("ExistingData", func(t *testing.T) {
 		t.Parallel()
 
 		arena := MultiSegment([][]byte{incrementingData(8), incrementingData(24)})
-		if n := arena.NumSegments(); n != 2 {
-			t.Errorf("MultiSegment(...).NumSegments() = %d; want 2", n)
-		}
-		data, err := segmentData(arena, 0)
-		if want := incrementingData(8); !bytes.Equal(data, want) {
-			t.Errorf("MultiSegment(...).Data(0) = %#v; want %#v", data, want)
-		}
-		if err != nil {
-			t.Errorf("MultiSegment(...).Data(0) error: %v", err)
-		}
-		data, err = segmentData(arena, 1)
-		if want := incrementingData(24); !bytes.Equal(data, want) {
-			t.Errorf("MultiSegment(...).Data(1) = %#v; want %#v", data, want)
-		}
-		if err != nil {
-			t.Errorf("MultiSegment(...).Data(1) error: %v", err)
-		}
-		_, err = segmentData(arena, 2)
-		if err == nil {
-			t.Error("MultiSegment(...).Data(2) succeeded; want error")
-		}
+		require.Equal(t, int64(2), arena.NumSegments())
+		data0 := segmentData(arena, 0)
+		require.Equal(t, incrementingData(8), data0)
+		data1 := segmentData(arena, 1)
+		require.Equal(t, incrementingData(24), data1)
+		data2 := segmentData(arena, 2)
+		require.Empty(t, data2)
 	})
 }
 

--- a/capability.go
+++ b/capability.go
@@ -59,7 +59,7 @@ func (i Interface) Message() *Message {
 	if i.seg == nil {
 		return nil
 	}
-	return i.seg.msg
+	return i.seg.Message()
 }
 
 // IsValid returns whether the interface is valid.

--- a/codec_test.go
+++ b/codec_test.go
@@ -81,12 +81,12 @@ type tooManySegsArena struct {
 
 func (t *tooManySegsArena) NumSegments() int64 { return 1<<32 + 1 }
 
-func (t *tooManySegsArena) Data(id SegmentID) ([]byte, error) {
-	return nil, errors.New("no data")
+func (t *tooManySegsArena) Segment(id SegmentID) *Segment {
+	return nil
 }
 
-func (t *tooManySegsArena) Allocate(minsz Size, segs map[SegmentID]*Segment) (SegmentID, []byte, error) {
-	return 0, nil, errors.New("cannot allocate")
+func (t *tooManySegsArena) Allocate(minsz Size, msg *Message, seg *Segment) (*Segment, address, error) {
+	return nil, 0, errors.New("cannot allocate")
 }
 
 func (t *tooManySegsArena) Release() {}

--- a/list.go
+++ b/list.go
@@ -100,7 +100,7 @@ func (p List) Message() *Message {
 	if p.seg == nil {
 		return nil
 	}
-	return p.seg.msg
+	return p.seg.Message()
 }
 
 // IsValid returns whether the list is valid.

--- a/message.go
+++ b/message.go
@@ -54,11 +54,6 @@ type Message struct {
 	// DepthLimit limits how deeply-nested a message structure can be.
 	// If not set, this defaults to 64.
 	DepthLimit uint
-
-	// mu protects the following fields:
-	mu       sync.Mutex
-	segs     map[SegmentID]*Segment
-	firstSeg Segment // Preallocated first segment. msg is non-nil once initialized.
 }
 
 // NewMessage creates a message with a new root and returns the first
@@ -109,14 +104,6 @@ func (m *Message) Release() {
 // not read.
 func (m *Message) Reset(arena Arena) (first *Segment, err error) {
 	m.capTable.Reset()
-	for k := range m.segs {
-		// Optimization: keep the first segment so that the re-used
-		// Message does not have to allocate a new one.
-		if k == 0 && m.segs[k] == &m.firstSeg {
-			continue
-		}
-		delete(m.segs, k)
-	}
 
 	if m.Arena != nil {
 		m.Arena.Release()
@@ -127,20 +114,18 @@ func (m *Message) Reset(arena Arena) (first *Segment, err error) {
 		TraverseLimit: m.TraverseLimit,
 		DepthLimit:    m.DepthLimit,
 		capTable:      m.capTable,
-		segs:          m.segs,
-		firstSeg:      Segment{msg: m},
 	}
 
 	if arena != nil {
 		switch arena.NumSegments() {
 		case 0:
-			if first, err = m.allocSegment(wordSize); err != nil {
+			if first, _, err = arena.Allocate(0, m, nil); err != nil {
 				return nil, exc.WrapError("new message", err)
 			}
 
 		case 1:
 			if first, err = m.Segment(0); err != nil {
-				return nil, exc.WrapError("new message", err)
+				return nil, exc.WrapError("Reset.Segment(0)", err)
 			}
 			if len(first.data) > 0 {
 				return nil, errors.New("new message: arena not empty")
@@ -153,7 +138,6 @@ func (m *Message) Reset(arena Arena) (first *Segment, err error) {
 		if first.ID() != 0 {
 			return nil, errors.New("new message: arena allocated first segment with non-zero ID")
 		}
-
 		seg, _, err := alloc(first, wordSize) // allocate root
 		if err != nil {
 			return nil, exc.WrapError("new message", err)
@@ -268,91 +252,14 @@ func (m *Message) NumSegments() int64 {
 
 // Segment returns the segment with the given ID.
 func (m *Message) Segment(id SegmentID) (*Segment, error) {
-	if int64(id) >= m.Arena.NumSegments() {
-		return nil, errors.New("segment " + str.Utod(id) + ": out of bounds")
+	seg := m.Arena.Segment(id)
+	if seg == nil {
+		return nil, errors.New("segment " + str.Utod(id) + " out of bounds in arena")
 	}
-	m.mu.Lock()
-	seg, err := m.segment(id)
-	m.mu.Unlock()
-	return seg, err
-}
-
-// segment returns the segment with the given ID, with no bounds
-// checking.  The caller must be holding m.mu.
-func (m *Message) segment(id SegmentID) (*Segment, error) {
-	if m.segs == nil && id == 0 && m.firstSeg.msg != nil && m.firstSeg.data != nil {
-		return &m.firstSeg, nil
+	if seg.msg != nil && seg.msg != m {
+		return nil, errors.New("segment " + str.Utod(id) + ": not of the same message")
 	}
-	if s := m.segs[id]; s != nil && s.data != nil {
-		return s, nil
-	}
-	if len(m.segs) == maxInt {
-		return nil, errors.New("segment " + str.Utod(id) + ": number of loaded segments exceeds int")
-	}
-	data, err := m.Arena.Data(id)
-	if err != nil {
-		return nil, exc.WrapError("load segment "+str.Utod(id), err)
-	}
-	s := m.setSegment(id, data)
-	return s, nil
-}
-
-// setSegment creates or updates the Segment with the given ID.
-// The caller must be holding m.mu.
-func (m *Message) setSegment(id SegmentID, data []byte) *Segment {
-	if m.segs == nil {
-		if id == 0 {
-			m.firstSeg = Segment{
-				id:   id,
-				msg:  m,
-				data: data,
-			}
-			return &m.firstSeg
-		}
-		m.segs = make(map[SegmentID]*Segment)
-		if m.firstSeg.msg != nil {
-			m.segs[0] = &m.firstSeg
-		}
-	} else if seg := m.segs[id]; seg != nil {
-		seg.data = data
-		return seg
-	}
-	seg := &Segment{
-		id:   id,
-		msg:  m,
-		data: data,
-	}
-	m.segs[id] = seg
-	return seg
-}
-
-// allocSegment creates or resizes an existing segment such that
-// cap(seg.Data) - len(seg.Data) >= sz.  The caller must not be holding
-// onto m.mu.
-func (m *Message) allocSegment(sz Size) (*Segment, error) {
-	if sz > maxAllocSize() {
-		return nil, errors.New("allocation: too large")
-	}
-
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	if len(m.segs) == maxInt {
-		return nil, errors.New("allocation: number of loaded segments exceeds int")
-	}
-
-	// Transition from sole segment to segment map?
-	if m.segs == nil && m.firstSeg.msg != nil {
-		m.segs = make(map[SegmentID]*Segment)
-		m.segs[0] = &m.firstSeg
-	}
-
-	id, data, err := m.Arena.Allocate(sz, m.segs)
-	if err != nil {
-		return nil, exc.WrapError("allocation", err)
-	}
-
-	seg := m.setSegment(id, data)
+	seg.msg = m
 	return seg, nil
 }
 
@@ -375,31 +282,25 @@ func (m *Message) Marshal() ([]byte, error) {
 		return nil, errors.New("marshal: header size overflows int")
 	}
 	var dataSize uint64
-	m.mu.Lock()
 	for i := int64(0); i < nsegs; i++ {
-		s, err := m.segment(SegmentID(i))
+		s, err := m.Segment(SegmentID(i))
 		if err != nil {
-			m.mu.Unlock()
 			return nil, exc.WrapError("marshal", err)
 		}
 		n := uint64(len(s.data))
 		if n%uint64(wordSize) != 0 {
-			m.mu.Unlock()
 			return nil, errors.New("marshal: segment " + str.Itod(i) + " not word-aligned")
 		}
 		if n > uint64(maxSegmentSize) {
-			m.mu.Unlock()
 			return nil, errors.New("marshal: segment " + str.Itod(i) + " too large")
 		}
 		dataSize += n
 		if dataSize > uint64(maxInt) {
-			m.mu.Unlock()
 			return nil, errors.New("marshal: message size overflows int")
 		}
 	}
 	total := hdrSize + dataSize
 	if total > uint64(maxInt) {
-		m.mu.Unlock()
 		return nil, errors.New("marshal: message size overflows int")
 	}
 
@@ -407,19 +308,16 @@ func (m *Message) Marshal() ([]byte, error) {
 	buf := make([]byte, int(hdrSize), int(total))
 	binary.LittleEndian.PutUint32(buf, uint32(nsegs-1))
 	for i := int64(0); i < nsegs; i++ {
-		s, err := m.segment(SegmentID(i))
+		s, err := m.Segment(SegmentID(i))
 		if err != nil {
-			m.mu.Unlock()
 			return nil, exc.WrapError("marshal", err)
 		}
 		if len(s.data)%int(wordSize) != 0 {
-			m.mu.Unlock()
 			return nil, errors.New("marshal: segment " + str.Itod(i) + " not word-aligned")
 		}
 		binary.LittleEndian.PutUint32(buf[int(i+1)*4:], uint32(len(s.data)/int(wordSize)))
 		buf = append(buf, s.data...)
 	}
-	m.mu.Unlock()
 	return buf, nil
 }
 
@@ -454,23 +352,26 @@ func alloc(s *Segment, sz Size) (*Segment, address, error) {
 	}
 	sz = sz.padToWord()
 
-	if !hasCapacity(s.data, sz) {
-		var err error
-		s, err = s.msg.allocSegment(sz)
-		if err != nil {
-			return nil, 0, errors.New("allocSegment failed: " + err.Error())
-		}
+	if s.msg == nil {
+		return nil, 0, errors.New("segment does not have a message assotiated with it")
+	}
+	if s.msg.Arena == nil {
+		return nil, 0, errors.New("message does not have an arena")
 	}
 
-	addr := address(len(s.data))
+	// TODO: From this point on, this could be changed to be a requirement
+	// for Arena implementations instead of relying on alloc() to do it.
+
+	s, addr, err := s.msg.Arena.Allocate(sz, s.msg, s)
+	if err != nil {
+		return s, addr, err
+	}
+
 	end, ok := addr.addSize(sz)
 	if !ok {
 		return nil, 0, errors.New("allocation: address overflow")
 	}
-	space := s.data[len(s.data):end]
-	s.data = s.data[:end]
-	for i := range space {
-		space[i] = 0
-	}
+
+	zeroSlice(s.data[addr:end])
 	return s, addr, nil
 }

--- a/pointer.go
+++ b/pointer.go
@@ -187,7 +187,7 @@ func (p Ptr) Message() *Message {
 	if p.seg == nil {
 		return nil
 	}
-	return p.seg.msg
+	return p.seg.Message()
 }
 
 // Default returns p if it is valid, otherwise it unmarshals def.

--- a/segment.go
+++ b/segment.go
@@ -17,7 +17,8 @@ type SegmentID uint32
 type Segment struct {
 	// msg associated with this segment. A Message instance m maintains the
 	// invariant that that all m.segs[].msg == m.
-	msg  *Message
+	msg *Message
+
 	id   SegmentID
 	data []byte
 }
@@ -25,6 +26,12 @@ type Segment struct {
 // Message returns the message that contains s.
 func (s *Segment) Message() *Message {
 	return s.msg
+}
+
+// BindTo binds the segment to a given message. This is usually only called by
+// Arena implementations and does not perform any kind of safety check.
+func (s *Segment) BindTo(m *Message) {
+	s.msg = m
 }
 
 // ID returns the segment's ID.
@@ -107,7 +114,7 @@ func (s *Segment) root() PointerList {
 		seg:        s,
 		length:     1,
 		size:       sz,
-		depthLimit: s.msg.depthLimit(),
+		depthLimit: s.Message().depthLimit(),
 	}
 }
 
@@ -115,7 +122,7 @@ func (s *Segment) lookupSegment(id SegmentID) (*Segment, error) {
 	if s.id == id {
 		return s, nil
 	}
-	return s.msg.Segment(id)
+	return s.Message().Segment(id)
 }
 
 func (s *Segment) readPtr(paddr address, depthLimit uint) (ptr Ptr, err error) {
@@ -135,7 +142,7 @@ func (s *Segment) readPtr(paddr address, depthLimit uint) (ptr Ptr, err error) {
 		if err != nil {
 			return Ptr{}, exc.WrapError("read pointer", err)
 		}
-		if !s.msg.canRead(sp.readSize()) {
+		if !s.Message().canRead(sp.readSize()) {
 			return Ptr{}, errors.New("read pointer: read traversal limit reached")
 		}
 		sp.depthLimit = depthLimit - 1
@@ -145,7 +152,7 @@ func (s *Segment) readPtr(paddr address, depthLimit uint) (ptr Ptr, err error) {
 		if err != nil {
 			return Ptr{}, exc.WrapError("read pointer", err)
 		}
-		if !s.msg.canRead(lp.readSize()) {
+		if !s.Message().canRead(lp.readSize()) {
 			return Ptr{}, errors.New("read pointer: read traversal limit reached")
 		}
 		lp.depthLimit = depthLimit - 1
@@ -377,8 +384,8 @@ func (s *Segment) writePtr(off address, src Ptr, forceCopy bool) error {
 		srcRaw = l.raw()
 	case interfacePtrType:
 		i := src.Interface()
-		if src.seg.msg != s.msg {
-			c := s.msg.CapTable().Add(i.Client().AddRef())
+		if src.seg.Message() != s.Message() {
+			c := s.Message().CapTable().Add(i.Client().AddRef())
 			i = NewInterface(s, c)
 		}
 		s.writeRawPointer(off, i.value(off))

--- a/segment_test.go
+++ b/segment_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/binary"
 	"fmt"
 	"testing"
+
+	"capnproto.org/go/capnp/v3/exp/bufferpool"
 )
 
 func TestSegmentInBounds(t *testing.T) {
@@ -666,6 +668,9 @@ func TestWriteDoubleFarPointer(t *testing.T) {
 			make([]byte, 0, 16),
 		}),
 	}
+
+	// Make arena writable again.
+	msg.Arena.(*MultiSegmentArena).bp = &bufferpool.Default
 	seg1, err := msg.Segment(1)
 	if err != nil {
 		t.Fatal("msg.Segment(1):", err)

--- a/struct.go
+++ b/struct.go
@@ -46,7 +46,7 @@ func NewRootStruct(s *Segment, sz ObjectSize) (Struct, error) {
 	if err != nil {
 		return st, err
 	}
-	if err := s.msg.SetRoot(st.ToPtr()); err != nil {
+	if err := s.Message().SetRoot(st.ToPtr()); err != nil {
 		return st, err
 	}
 	return st, nil
@@ -75,7 +75,7 @@ func (p Struct) Message() *Message {
 	if p.seg == nil {
 		return nil
 	}
-	return p.seg.msg
+	return p.seg.Message()
 }
 
 // IsValid returns whether the struct is valid.


### PR DESCRIPTION
This PR performs the first refactor of the Arena interface and its existing implementations.

The ultimate goal for this and following arena refactor PRs is to make the API
saner, more performant and allow for third party creation of Arena
implementations (which is not possible today due to need to access private
fields within Segment).

This PR attempts to maintain as much as possible the interface and implied
semantics of the Arena interface, while still improving the overall API and
performance. 

I have attempted to (as much as feasible) not break any of the current
assumptions that external code may make about the behavior of the existing Arena
implementations. This has proven hard, due to the high coupling between the
implementations and the Message and Segment types (which is partially unwound
here). This can be asserted by reviewers by noting how few of the existing tests
had to be fixed.

In the future, I hope to be more aggressive in the changes proposed, thus this
initial PR is meant to serve as base, upon which more significant changes will
be made.

<details>
<summary>Benchstat comparison before/after refactor</summary>

Note: the benchmarks "old" benchmarks were run on the commit titled "Fix reuse of SingleSegmentArena" in order for the fixes in that commit to apply both before and after the refactor.

```
name                                        old time/op    new time/op     delta
MessageGetFirstSegment-7                       363ns ± 2%      205ns ± 1%   -43.35%  (p=0.000 n=10+10)
TextMovementBetweenSegments-7                  434µs ± 1%      443µs ± 2%    +2.01%  (p=0.000 n=10+10)
Marshal-7                                     1.44µs ± 1%     1.23µs ± 1%   -14.71%  (p=0.000 n=10+9)
Marshal_ReuseMsg-7                             894ns ± 1%      702ns ± 2%   -21.51%  (p=0.000 n=10+10)
Unmarshal-7                                    947ns ± 1%      855ns ± 1%    -9.77%  (p=0.000 n=8+10)
Unmarshal_Reuse-7                              589ns ± 2%      557ns ± 1%    -5.34%  (p=0.000 n=10+9)
Decode-7                                      8.83ms ± 1%     7.58ms ± 0%   -14.11%  (p=0.000 n=10+10)
Growth/SingleSegment/release=false-7          10.4ms ± 3%     10.8ms ± 2%    +3.44%  (p=0.000 n=9+10)
Growth/MultiSegment/release=false-7           13.2ms ± 1%     10.3ms ± 2%   -21.96%  (p=0.000 n=10+10)
Growth/SingleSegment/release=true-7           10.7ms ± 4%     10.8ms ± 1%      ~     (p=0.631 n=10+10)
Growth/MultiSegment/release=true-7            12.8ms ± 1%     10.2ms ± 2%   -20.39%  (p=0.000 n=10+10)
SmallMessage/SingleSegment/release=false-7    1.34µs ± 1%     1.13µs ± 1%   -15.58%  (p=0.000 n=10+10)
SmallMessage/MultiSegment/release=false-7     1.53µs ± 3%     1.20µs ± 1%   -21.60%  (p=0.000 n=9+9)
SmallMessage/SingleSegment/release=true-7     1.08µs ± 1%     0.67µs ± 1%   -38.45%  (p=0.000 n=9+10)
SmallMessage/MultiSegment/release=true-7      1.01µs ± 1%     0.63µs ± 2%   -38.00%  (p=0.000 n=8+10)
Pool-7                                        64.5ns ± 1%     64.7ns ± 2%      ~     (p=0.491 n=10+10)
Pack-7                                        13.8µs ± 3%     13.8µs ± 1%      ~     (p=0.239 n=10+10)
Unpack-7                                      10.9µs ± 1%     10.9µs ± 1%      ~     (p=0.853 n=10+10)
Unpack_Large-7                                2.06µs ± 2%     2.06µs ± 1%      ~     (p=0.542 n=10+10)
Reader-7                                      22.9µs ± 2%     23.0µs ± 2%      ~     (p=0.089 n=10+10)
Reader_Large-7                                30.7µs ± 1%     30.2µs ± 2%    -1.45%  (p=0.002 n=10+10)
Extract-7                                     21.1µs ± 2%     20.9µs ± 1%    -1.09%  (p=0.001 n=10+10)
Insert-7                                      21.0µs ± 1%     21.1µs ± 1%      ~     (p=0.143 n=10+10)
PingPong-7                                    46.8µs ± 2%     46.1µs ± 1%    -1.37%  (p=0.004 n=10+8)

name                                        old alloc/op   new alloc/op    delta
MessageGetFirstSegment-7                       24.0B ± 0%       0.0B       -100.00%  (p=0.000 n=10+10)
Marshal-7                                     1.50kB ± 0%     1.32kB ± 0%   -12.21%  (p=0.000 n=10+10)
Marshal_ReuseMsg-7                              120B ± 0%        96B ± 0%   -20.00%  (p=0.000 n=10+10)
Unmarshal-7                                     592B ± 0%       336B ± 0%   -43.24%  (p=0.000 n=10+10)
Unmarshal_Reuse-7                              0.00B           0.00B           ~     (all equal)
Decode-7                                      7.70MB ± 0%     5.17MB ± 0%   -32.95%  (p=0.000 n=10+10)
Growth/SingleSegment/release=false-7          4.35MB ± 0%     4.35MB ± 0%    +0.02%  (p=0.000 n=10+9)
Growth/MultiSegment/release=false-7           1.59MB ± 0%     1.59MB ± 0%    -0.04%  (p=0.000 n=10+9)
Growth/SingleSegment/release=true-7           4.35MB ± 0%     4.35MB ± 0%    +0.02%  (p=0.000 n=10+10)
Growth/MultiSegment/release=true-7             537kB ± 1%      535kB ± 1%    -0.32%  (p=0.019 n=10+10)
SmallMessage/SingleSegment/release=false-7    1.41kB ± 0%     1.22kB ± 0%   -13.30%  (p=0.000 n=10+10)
SmallMessage/MultiSegment/release=false-7     1.82kB ± 0%     1.42kB ± 0%   -22.36%  (p=0.000 n=8+10)
SmallMessage/SingleSegment/release=true-7       328B ± 0%        80B ± 0%   -75.61%  (p=0.000 n=10+10)
SmallMessage/MultiSegment/release=true-7        304B ± 0%        80B ± 0%   -73.68%  (p=0.000 n=10+10)
Pool-7                                         0.00B           0.00B           ~     (all equal)
Extract-7                                     16.2kB ± 0%     15.7kB ± 0%    -3.16%  (p=0.000 n=10+10)
Insert-7                                      15.8kB ± 0%     15.5kB ± 0%    -1.76%  (p=0.000 n=10+10)

name                                        old allocs/op  new allocs/op   delta
MessageGetFirstSegment-7                        1.00 ± 0%       0.00       -100.00%  (p=0.000 n=10+10)
Marshal-7                                       7.00 ± 0%       5.00 ± 0%   -28.57%  (p=0.000 n=10+10)
Marshal_ReuseMsg-7                              2.00 ± 0%       1.00 ± 0%   -50.00%  (p=0.000 n=10+10)
Unmarshal-7                                     3.00 ± 0%       3.00 ± 0%      ~     (all equal)
Unmarshal_Reuse-7                               0.00            0.00           ~     (all equal)
Decode-7                                       50.1k ± 0%      50.1k ± 0%    -0.06%  (p=0.000 n=10+10)
Growth/SingleSegment/release=false-7            19.4 ± 7%       19.7 ± 4%      ~     (p=0.666 n=10+10)
Growth/MultiSegment/release=false-7             26.0 ± 0%       20.0 ± 0%   -23.08%  (p=0.000 n=10+10)
Growth/SingleSegment/release=true-7             19.4 ± 7%       19.0 ± 0%      ~     (p=0.092 n=10+9)
Growth/MultiSegment/release=true-7              10.0 ± 0%        4.0 ± 0%   -60.00%  (p=0.000 n=9+10)
SmallMessage/SingleSegment/release=false-7      6.00 ± 0%       4.00 ± 0%   -33.33%  (p=0.000 n=10+10)
SmallMessage/MultiSegment/release=false-7       7.00 ± 0%       5.00 ± 0%   -28.57%  (p=0.000 n=10+10)
SmallMessage/SingleSegment/release=true-7       4.00 ± 0%       1.00 ± 0%   -75.00%  (p=0.000 n=10+10)
SmallMessage/MultiSegment/release=true-7        3.00 ± 0%       1.00 ± 0%   -66.67%  (p=0.000 n=10+10)
Pool-7                                          0.00            0.00           ~     (all equal)
Extract-7                                       32.0 ± 0%       32.0 ± 0%      ~     (all equal)
Insert-7                                        29.0 ± 0%       29.0 ± 0%      ~     (all equal)

name                                        old speed      new speed       delta
Decode-7                                     109MB/s ± 1%    127MB/s ± 0%   +16.43%  (p=0.000 n=10+10)
Growth/SingleSegment/release=false-7         101MB/s ± 4%     97MB/s ± 2%    -3.36%  (p=0.000 n=9+10)
Growth/MultiSegment/release=false-7         79.2MB/s ± 1%  101.4MB/s ± 2%   +28.14%  (p=0.000 n=10+10)
Growth/SingleSegment/release=true-7         98.0MB/s ± 4%   97.0MB/s ± 1%      ~     (p=0.644 n=10+10)
Growth/MultiSegment/release=true-7          81.8MB/s ± 1%  102.7MB/s ± 2%   +25.62%  (p=0.000 n=10+10)
SmallMessage/SingleSegment/release=false-7  53.7MB/s ± 1%   63.6MB/s ± 1%   +18.47%  (p=0.000 n=10+10)
SmallMessage/MultiSegment/release=false-7   46.8MB/s ± 4%   59.9MB/s ± 1%   +28.06%  (p=0.000 n=10+9)
SmallMessage/SingleSegment/release=true-7   66.4MB/s ± 1%  107.9MB/s ± 1%   +62.48%  (p=0.000 n=9+10)
SmallMessage/MultiSegment/release=true-7    71.1MB/s ± 1%  114.6MB/s ± 1%   +61.09%  (p=0.000 n=9+10)
Pack-7                                       742MB/s ± 3%    740MB/s ± 1%      ~     (p=0.239 n=10+10)
Unpack-7                                     938MB/s ± 1%    939MB/s ± 1%      ~     (p=0.853 n=10+10)
Unpack_Large-7                              25.4GB/s ± 2%   25.4GB/s ± 1%      ~     (p=0.529 n=10+10)
Reader-7                                     448MB/s ± 2%    444MB/s ± 2%      ~     (p=0.089 n=10+10)
Reader_Large-7                              1.71GB/s ± 1%   1.73GB/s ± 2%    +1.47%  (p=0.002 n=10+10)
```

</details>

As can be seen, the absolute majority of the benchmarks is improved by this PR.

The second commit (titled "Refactor Internals") has further details on which
specific changes were done.



