### PR TITLE
multi: Make NewMessage() usable for creating messages for reading

### DIFF
--- a/answer_test.go
+++ b/answer_test.go
@@ -59,7 +59,7 @@ func TestPromiseFulfill(t *testing.T) {
 	t.Run("Done", func(t *testing.T) {
 		p := NewPromise(dummyMethod, dummyPipelineCaller{}, nil)
 		done := p.Answer().Done()
-		msg, seg, _ := NewMessage(SingleSegment(nil))
+		msg, seg := NewSingleSegmentMessage(nil)
 		defer msg.Release()
 
 		res, _ := NewStruct(seg, ObjectSize{DataSize: 8})
@@ -75,7 +75,7 @@ func TestPromiseFulfill(t *testing.T) {
 		p := NewPromise(dummyMethod, dummyPipelineCaller{}, nil)
 		defer p.ReleaseClients()
 		ans := p.Answer()
-		msg, seg, _ := NewMessage(SingleSegment(nil))
+		msg, seg := NewSingleSegmentMessage(nil)
 		defer msg.Release()
 
 		res, _ := NewStruct(seg, ObjectSize{DataSize: 8})
@@ -99,7 +99,7 @@ func TestPromiseFulfill(t *testing.T) {
 		h := new(dummyHook)
 		c := NewClient(h)
 		defer c.Release()
-		msg, seg, _ := NewMessage(SingleSegment(nil))
+		msg, seg := NewSingleSegmentMessage(nil)
 		defer msg.Release()
 
 		res, _ := NewStruct(seg, ObjectSize{PointerCount: 3})

--- a/canonical.go
+++ b/canonical.go
@@ -10,7 +10,7 @@ import (
 // for equivalent structs, even as the schema evolves.  The blob is
 // suitable for hashing or signing.
 func Canonicalize(s Struct) ([]byte, error) {
-	msg, seg, _ := NewMessage(SingleSegment(nil))
+	msg, seg := NewSingleSegmentMessage(nil)
 	if !s.IsValid() {
 		return seg.Data(), nil
 	}

--- a/canonical.go
+++ b/canonical.go
@@ -12,6 +12,13 @@ import (
 func Canonicalize(s Struct) ([]byte, error) {
 	msg, seg := NewSingleSegmentMessage(nil)
 	if !s.IsValid() {
+		// Ensure compatbility to existing behavior: even if the struct
+		// is not valid, at least the root pointer is allocated and
+		// returned as canonical. Without this,
+		// TestCanonicalize/Struct{} fails.
+		if _, err := msg.allocRootPointerSpace(); err != nil {
+			return nil, err
+		}
 		return seg.Data(), nil
 	}
 	root, err := NewRootStruct(seg, canonicalStructSize(s))

--- a/canonical_test.go
+++ b/canonical_test.go
@@ -19,7 +19,7 @@ func TestCanonicalize(t *testing.T) {
 	}, {
 		name: "empty struct",
 		f: func() Struct {
-			_, seg, _ := NewMessage(SingleSegment(nil))
+			_, seg := NewSingleSegmentMessage(nil)
 			s, _ := NewStruct(seg, ObjectSize{})
 			return s
 		},
@@ -27,7 +27,7 @@ func TestCanonicalize(t *testing.T) {
 	}, {
 		name: "zero data, zero pointer struct",
 		f: func() Struct {
-			_, seg, _ := NewMessage(SingleSegment(nil))
+			_, seg := NewSingleSegmentMessage(nil)
 			s, _ := NewStruct(seg, ObjectSize{DataSize: 8, PointerCount: 1})
 			return s
 		},
@@ -35,7 +35,7 @@ func TestCanonicalize(t *testing.T) {
 	}, {
 		name: "one word data struct",
 		f: func() Struct {
-			_, seg, _ := NewMessage(SingleSegment(nil))
+			_, seg := NewSingleSegmentMessage(nil)
 			s, _ := NewStruct(seg, ObjectSize{DataSize: 8, PointerCount: 1})
 			s.SetUint16(0, 0xbeef)
 			return s
@@ -47,7 +47,7 @@ func TestCanonicalize(t *testing.T) {
 	}, {
 		name: "two pointers to zero structs",
 		f: func() Struct {
-			_, seg, _ := NewMessage(SingleSegment(nil))
+			_, seg := NewSingleSegmentMessage(nil)
 			s, _ := NewStruct(seg, ObjectSize{PointerCount: 2})
 			e1, _ := NewStruct(seg, ObjectSize{DataSize: 8})
 			e2, _ := NewStruct(seg, ObjectSize{DataSize: 8})
@@ -63,7 +63,7 @@ func TestCanonicalize(t *testing.T) {
 	}, {
 		name: "pointer to interface",
 		f: func() Struct {
-			_, seg, _ := NewMessage(SingleSegment(nil))
+			_, seg := NewSingleSegmentMessage(nil)
 			s, _ := NewStruct(seg, ObjectSize{PointerCount: 2})
 			iface := NewInterface(seg, 1)
 			s.SetPtr(0, iface.ToPtr())
@@ -76,7 +76,7 @@ func TestCanonicalize(t *testing.T) {
 	}, {
 		name: "int list",
 		f: func() Struct {
-			_, seg, _ := NewMessage(SingleSegment(nil))
+			_, seg := NewSingleSegmentMessage(nil)
 			s, _ := NewStruct(seg, ObjectSize{PointerCount: 1})
 			l, _ := NewInt8List(seg, 5)
 			s.SetPtr(0, l.ToPtr())
@@ -95,7 +95,7 @@ func TestCanonicalize(t *testing.T) {
 	}, {
 		name: "zero int list",
 		f: func() Struct {
-			_, seg, _ := NewMessage(SingleSegment(nil))
+			_, seg := NewSingleSegmentMessage(nil)
 			s, _ := NewStruct(seg, ObjectSize{PointerCount: 1})
 			l, _ := NewInt8List(seg, 5)
 			s.SetPtr(0, l.ToPtr())
@@ -110,7 +110,7 @@ func TestCanonicalize(t *testing.T) {
 	}, {
 		name: "struct list",
 		f: func() Struct {
-			_, seg, _ := NewMessage(SingleSegment(nil))
+			_, seg := NewSingleSegmentMessage(nil)
 			s, _ := NewStruct(seg, ObjectSize{PointerCount: 1})
 			l, _ := NewCompositeList(seg, ObjectSize{DataSize: 8, PointerCount: 1}, 2)
 			s.SetPtr(0, l.ToPtr())
@@ -133,7 +133,7 @@ func TestCanonicalize(t *testing.T) {
 	}, {
 		name: "zero struct list",
 		f: func() Struct {
-			_, seg, _ := NewMessage(SingleSegment(nil))
+			_, seg := NewSingleSegmentMessage(nil)
 			s, _ := NewStruct(seg, ObjectSize{PointerCount: 1})
 			l, _ := NewCompositeList(seg, ObjectSize{DataSize: 16, PointerCount: 2}, 3)
 			s.SetPtr(0, l.ToPtr())
@@ -148,7 +148,7 @@ func TestCanonicalize(t *testing.T) {
 	}, {
 		name: "zero-length struct list",
 		f: func() Struct {
-			_, seg, _ := NewMessage(SingleSegment(nil))
+			_, seg := NewSingleSegmentMessage(nil)
 			s, _ := NewStruct(seg, ObjectSize{PointerCount: 1})
 			l, _ := NewCompositeList(seg, ObjectSize{DataSize: 16, PointerCount: 2}, 0)
 			s.SetPtr(0, l.ToPtr())

--- a/capability_test.go
+++ b/capability_test.go
@@ -357,10 +357,8 @@ func (dr *dummyReturner) AllocResults(sz ObjectSize) (Struct, error) {
 	if dr.s.IsValid() {
 		return Struct{}, errors.New("AllocResults called multiple times")
 	}
-	_, seg, err := NewMessage(SingleSegment(nil))
-	if err != nil {
-		return Struct{}, err
-	}
+	_, seg := NewSingleSegmentMessage(nil)
+	var err error
 	dr.s, err = NewRootStruct(seg, sz)
 	return dr.s, err
 }
@@ -377,10 +375,7 @@ func (dr *dummyReturner) ReleaseResults() {
 }
 
 func TestToInterface(t *testing.T) {
-	_, seg, err := NewMessage(SingleSegment(nil))
-	if err != nil {
-		t.Fatal(err)
-	}
+	_, seg := NewSingleSegmentMessage(nil)
 	tests := []struct {
 		ptr Ptr
 		in  Interface
@@ -399,10 +394,7 @@ func TestToInterface(t *testing.T) {
 }
 
 func TestInterface_value(t *testing.T) {
-	_, seg, err := NewMessage(SingleSegment(nil))
-	if err != nil {
-		t.Fatal(err)
-	}
+	_, seg := NewSingleSegmentMessage(nil)
 	tests := []struct {
 		in  Interface
 		val rawPointer
@@ -421,10 +413,7 @@ func TestInterface_value(t *testing.T) {
 }
 
 func TestTransform(t *testing.T) {
-	_, s, err := NewMessage(SingleSegment(nil))
-	if err != nil {
-		t.Fatal(err)
-	}
+	_, s := NewSingleSegmentMessage(nil)
 	root, err := NewStruct(s, ObjectSize{PointerCount: 2})
 	if err != nil {
 		t.Fatal(err)
@@ -442,7 +431,7 @@ func TestTransform(t *testing.T) {
 	b.SetUint64(0, 2)
 	a.SetPtr(0, b.ToPtr())
 
-	dmsg, d, err := NewMessage(SingleSegment(nil))
+	dmsg, d := NewSingleSegmentMessage(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -675,20 +664,17 @@ func deepPointerEqual(a, b Ptr) bool {
 	if !a.IsValid() || !b.IsValid() {
 		return false
 	}
-	msgA, _, _ := NewMessage(SingleSegment(nil))
+	msgA, _ := NewSingleSegmentMessage(nil)
 	msgA.SetRoot(a)
 	abytes, _ := msgA.Marshal()
-	msgB, _, _ := NewMessage(SingleSegment(nil))
+	msgB, _ := NewSingleSegmentMessage(nil)
 	msgB.SetRoot(b)
 	bbytes, _ := msgB.Marshal()
 	return bytes.Equal(abytes, bbytes)
 }
 
 func newEmptyStruct() Struct {
-	_, seg, err := NewMessage(SingleSegment(nil))
-	if err != nil {
-		panic(err)
-	}
+	_, seg := NewSingleSegmentMessage(nil)
 	s, err := NewRootStruct(seg, ObjectSize{})
 	if err != nil {
 		panic(err)

--- a/capnpc-go/capnpc-go.go
+++ b/capnpc-go/capnpc-go.go
@@ -168,7 +168,7 @@ func (g *generator) defineSchemaVar() error {
 	}
 	sort.Sort(uint64Slice(ids))
 
-	msg, seg, _ := capnp.NewMessage(capnp.SingleSegment(nil))
+	msg, seg := capnp.NewSingleSegmentMessage(nil)
 	req, _ := schema.NewRootCodeGeneratorRequest(seg)
 	// TODO(light): find largest object size and use that to allocate list
 	nodes, _ := req.NewNodes(int32(len(g.nodes)))

--- a/capnpc-go/fileparts.go
+++ b/capnpc-go/fileparts.go
@@ -38,11 +38,8 @@ func (sd *staticData) init(fileID uint64) {
 }
 
 func (sd *staticData) copyData(obj capnp.Ptr) (staticDataRef, error) {
-	m, _, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		return staticDataRef{}, err
-	}
-	err = m.SetRoot(obj)
+	m, _ := capnp.NewSingleSegmentMessage(nil)
+	err := m.SetRoot(obj)
 	if err != nil {
 		return staticDataRef{}, err
 	}

--- a/codec.go
+++ b/codec.go
@@ -66,13 +66,14 @@ func (d *Decoder) Decode() (*Message, error) {
 	}
 
 	// Read segments.
-	buf := bufferpool.Default.Get(int(total))
+	bp := &bufferpool.Default
+	buf := bp.Get(int(total))
 	if _, err := io.ReadFull(d.r, buf); err != nil {
 		return nil, exc.WrapError("decode: read segments", err)
 	}
 
 	arena := MultiSegment(nil)
-	if err = arena.demux(hdr, buf); err != nil {
+	if err = arena.demux(hdr, buf, bp); err != nil {
 		return nil, exc.WrapError("decode", err)
 	}
 
@@ -162,7 +163,7 @@ func Unmarshal(data []byte) (*Message, error) {
 	}
 
 	arena := MultiSegment(nil)
-	if err := arena.demux(hdr, data); err != nil {
+	if err := arena.demux(hdr, data, nil); err != nil {
 		return nil, exc.WrapError("unmarshal", err)
 	}
 

--- a/encoding/text/marshal.go
+++ b/encoding/text/marshal.go
@@ -74,7 +74,7 @@ func (enc *Encoder) Encode(typeID uint64, s capnp.Struct) error {
 
 // EncodeList writes the text representation of struct list l to the stream.
 func (enc *Encoder) EncodeList(typeID uint64, l capnp.List) error {
-	_, seg, _ := capnp.NewMessage(capnp.SingleSegment(nil))
+	_, seg := capnp.NewSingleSegmentMessage(nil)
 	typ, _ := schema.NewRootType(seg)
 	typ.SetStructType()
 	typ.StructType().SetTypeId(typeID)

--- a/example/books/ex1/books1.go
+++ b/example/books/ex1/books1.go
@@ -9,10 +9,7 @@ import (
 
 func main() {
 	// Make a brand new empty message.  A Message allocates Cap'n Proto structs.
-	msg, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		panic(err)
-	}
+	msg, seg := capnp.NewSingleSegmentMessage(nil)
 
 	// Create a new Book struct.  Every message must have a root struct.
 	book, err := books.NewRootBook(seg)

--- a/example_test.go
+++ b/example_test.go
@@ -10,10 +10,7 @@ import (
 
 func Example() {
 	// Make a brand new empty message.
-	msg, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		panic(err)
-	}
+	msg, seg := capnp.NewSingleSegmentMessage(nil)
 
 	// If you want runtime-type identification, this is easily obtained. Just
 	// wrap everything in a struct that contains a single anoymous union (e.g. struct Z).
@@ -87,11 +84,7 @@ func Example() {
 }
 
 func ExampleUnmarshal() {
-	msg, s, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		fmt.Printf("allocation error %v\n", err)
-		return
-	}
+	msg, s := capnp.NewSingleSegmentMessage(nil)
 	d, err := air.NewRootZdate(s)
 	if err != nil {
 		fmt.Printf("root error %v\n", err)

--- a/integration_test.go
+++ b/integration_test.go
@@ -1832,13 +1832,11 @@ func BenchmarkDecode(b *testing.B) {
 func TestPointerTraverseDefense(t *testing.T) {
 	t.Parallel()
 	const limit = 128
-	msg := &capnp.Message{
-		Arena: capnp.SingleSegment([]byte{
-			0, 0, 0, 0, 1, 0, 0, 0, // root 1-word struct pointer to next word
-			0, 0, 0, 0, 0, 0, 0, 0, // struct's data
-		}),
-		TraverseLimit: limit * 8,
-	}
+	msg, _ := capnp.NewSingleSegmentMessage([]byte{
+		0, 0, 0, 0, 1, 0, 0, 0, // root 1-word struct pointer to next word
+		0, 0, 0, 0, 0, 0, 0, 0, // struct's data
+	})
+	msg.TraverseLimit = limit * 8
 
 	for i := 0; i < limit; i++ {
 		_, err := msg.Root()
@@ -1855,13 +1853,11 @@ func TestPointerTraverseDefense(t *testing.T) {
 func TestPointerDepthDefense(t *testing.T) {
 	t.Parallel()
 	const limit = 64
-	msg := &capnp.Message{
-		Arena: capnp.SingleSegment([]byte{
-			0, 0, 0, 0, 0, 0, 1, 0, // root 1-pointer struct pointer to next word
-			0xfc, 0xff, 0xff, 0xff, 0, 0, 1, 0, // root struct pointer that points back to itself
-		}),
-		DepthLimit: limit,
-	}
+	msg, _ := capnp.NewSingleSegmentMessage([]byte{
+		0, 0, 0, 0, 0, 0, 1, 0, // root 1-pointer struct pointer to next word
+		0xfc, 0xff, 0xff, 0xff, 0, 0, 1, 0, // root struct pointer that points back to itself
+	})
+	msg.DepthLimit = limit
 	root, err := msg.Root()
 	if err != nil {
 		t.Fatal("Root:", err)
@@ -1894,14 +1890,12 @@ func TestPointerDepthDefense(t *testing.T) {
 func TestPointerDepthDefenseAcrossStructsAndLists(t *testing.T) {
 	t.Parallel()
 	const limit = 63
-	msg := &capnp.Message{
-		Arena: capnp.SingleSegment([]byte{
-			0, 0, 0, 0, 0, 0, 1, 0, // root 1-pointer struct pointer to next word
-			0x01, 0, 0, 0, 0x0e, 0, 0, 0, // list pointer to 1-element list of pointer (next word)
-			0xf8, 0xff, 0xff, 0xff, 0, 0, 1, 0, // struct pointer to previous word
-		}),
-		DepthLimit: limit,
-	}
+	msg, _ := capnp.NewSingleSegmentMessage([]byte{
+		0, 0, 0, 0, 0, 0, 1, 0, // root 1-pointer struct pointer to next word
+		0x01, 0, 0, 0, 0x0e, 0, 0, 0, // list pointer to 1-element list of pointer (next word)
+		0xf8, 0xff, 0xff, 0xff, 0, 0, 1, 0, // struct pointer to previous word
+	})
+	msg.DepthLimit = limit
 
 	toStruct := func(p capnp.Ptr, err error) (capnp.Struct, error) {
 		if err != nil {
@@ -2083,11 +2077,10 @@ func TestSetEmptyTextWithDefault(t *testing.T) {
 
 func TestFuzzedListOutOfBounds(t *testing.T) {
 	t.Parallel()
-	msg := &capnp.Message{
-		Arena: capnp.SingleSegment([]byte(
-			"\x00\x00\x00\x00\x03\x00\x01\x00\x0f\x000000000000" +
-				"000000000000\x01\x00\x00\x00\x13\x00\x00\x000\x00\x00\x00\x00\x00\x00\x00")),
-	}
+	msg, _ := capnp.NewSingleSegmentMessage([]byte(
+		"\x00\x00\x00\x00\x03\x00\x01\x00\x0f\x000000000000" +
+			"000000000000\x01\x00\x00\x00\x13\x00\x00\x000\x00\x00\x00\x00\x00\x00\x00"))
+
 	z, err := air.ReadRootZ(msg)
 	if err != nil {
 		t.Fatal("ReadRootZ:", err)

--- a/integration_test.go
+++ b/integration_test.go
@@ -63,10 +63,7 @@ func makeMarshalTests(t *testing.T) []marshalTest {
 	}
 
 	{
-		msg, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-		if err != nil {
-			t.Fatal(err)
-		}
+		msg, seg := capnp.NewSingleSegmentMessage(nil)
 		if _, err := air.NewRootZjob(seg); err != nil {
 			t.Fatal(err)
 		}
@@ -85,10 +82,7 @@ func makeMarshalTests(t *testing.T) []marshalTest {
 	}
 
 	{
-		msg, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-		if err != nil {
-			t.Fatal(err)
-		}
+		msg, seg := capnp.NewSingleSegmentMessage(nil)
 		zjob, err := air.NewRootZjob(seg)
 		if err != nil {
 			t.Fatal(err)
@@ -112,10 +106,7 @@ func makeMarshalTests(t *testing.T) []marshalTest {
 	}
 
 	{
-		msg, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-		if err != nil {
-			t.Fatal(err)
-		}
+		msg, seg := capnp.NewSingleSegmentMessage(nil)
 		zjob, err := air.NewRootZjob(seg)
 		if err != nil {
 			t.Fatal(err)
@@ -144,10 +135,7 @@ func makeMarshalTests(t *testing.T) []marshalTest {
 	}
 
 	{
-		msg, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-		if err != nil {
-			t.Fatal(err)
-		}
+		msg, seg := capnp.NewSingleSegmentMessage(nil)
 		zjob, err := air.NewRootZjob(seg)
 		if err != nil {
 			t.Fatal(err)
@@ -180,10 +168,7 @@ func makeMarshalTests(t *testing.T) []marshalTest {
 	}
 
 	{
-		msg, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-		if err != nil {
-			t.Fatal(err)
-		}
+		msg, seg := capnp.NewSingleSegmentMessage(nil)
 		server, err := air.NewRootZserver(seg)
 		if err != nil {
 			t.Fatal(err)
@@ -209,10 +194,7 @@ func makeMarshalTests(t *testing.T) []marshalTest {
 	}
 
 	{
-		msg, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-		if err != nil {
-			t.Fatal(err)
-		}
+		msg, seg := capnp.NewSingleSegmentMessage(nil)
 		server, err := air.NewRootZserver(seg)
 		if err != nil {
 			t.Fatal(err)
@@ -252,10 +234,7 @@ func makeMarshalTests(t *testing.T) []marshalTest {
 	}
 
 	{
-		msg, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-		if err != nil {
-			t.Fatal(err)
-		}
+		msg, seg := capnp.NewSingleSegmentMessage(nil)
 		server, err := air.NewRootZserver(seg)
 		if err != nil {
 			t.Fatal(err)
@@ -292,14 +271,8 @@ func makeMarshalTests(t *testing.T) []marshalTest {
 	}
 
 	{
-		msg, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-		if err != nil {
-			t.Fatal(err)
-		}
-		_, scratch, err := capnp.NewMessage(capnp.SingleSegment(nil))
-		if err != nil {
-			t.Fatal(err)
-		}
+		msg, seg := capnp.NewSingleSegmentMessage(nil)
+		_, scratch := capnp.NewSingleSegmentMessage(nil)
 
 		// in seg
 		segbag, err := air.NewRootBag(seg)
@@ -337,14 +310,8 @@ func makeMarshalTests(t *testing.T) []marshalTest {
 	}
 
 	{
-		msg, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-		if err != nil {
-			t.Fatal(err)
-		}
-		_, scratch, err := capnp.NewMessage(capnp.SingleSegment(nil))
-		if err != nil {
-			t.Fatal(err)
-		}
+		msg, seg := capnp.NewSingleSegmentMessage(nil)
+		_, scratch := capnp.NewSingleSegmentMessage(nil)
 
 		// in seg
 		segbag, err := air.NewRootBag(seg)
@@ -386,14 +353,8 @@ func makeMarshalTests(t *testing.T) []marshalTest {
 	}
 
 	{
-		msg, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-		if err != nil {
-			t.Fatal(err)
-		}
-		_, scratch, err := capnp.NewMessage(capnp.SingleSegment(nil))
-		if err != nil {
-			t.Fatal(err)
-		}
+		msg, seg := capnp.NewSingleSegmentMessage(nil)
+		_, scratch := capnp.NewSingleSegmentMessage(nil)
 
 		// in seg
 		segbag, err := air.NewRootBag(seg)
@@ -445,14 +406,8 @@ func makeMarshalTests(t *testing.T) []marshalTest {
 	}
 
 	{
-		msg, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-		if err != nil {
-			t.Fatal(err)
-		}
-		_, scratch, err := capnp.NewMessage(capnp.SingleSegment(nil))
-		if err != nil {
-			t.Fatal(err)
-		}
+		msg, seg := capnp.NewSingleSegmentMessage(nil)
+		_, scratch := capnp.NewSingleSegmentMessage(nil)
 
 		// in seg
 		segbag, err := air.NewRootBag(seg)
@@ -508,14 +463,8 @@ func makeMarshalTests(t *testing.T) []marshalTest {
 	}
 
 	{
-		msg, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-		if err != nil {
-			t.Fatal(err)
-		}
-		_, scratch, err := capnp.NewMessage(capnp.SingleSegment(nil))
-		if err != nil {
-			t.Fatal(err)
-		}
+		msg, seg := capnp.NewSingleSegmentMessage(nil)
+		_, scratch := capnp.NewSingleSegmentMessage(nil)
 
 		// in seg
 		segbag, err := air.NewRootBag(seg)
@@ -560,10 +509,7 @@ func makeMarshalTests(t *testing.T) []marshalTest {
 	}
 
 	{
-		msg, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-		if err != nil {
-			t.Fatal(err)
-		}
+		msg, seg := capnp.NewSingleSegmentMessage(nil)
 		holder, err := air.NewRootHoldsVerEmptyList(seg)
 		if err != nil {
 			t.Fatal(err)
@@ -591,10 +537,7 @@ func makeMarshalTests(t *testing.T) []marshalTest {
 	}
 
 	{
-		msg, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-		if err != nil {
-			t.Fatal(err)
-		}
+		msg, seg := capnp.NewSingleSegmentMessage(nil)
 		holder, err := air.NewRootNester1Capn(seg)
 		if err != nil {
 			t.Fatal(err)
@@ -619,10 +562,7 @@ func makeMarshalTests(t *testing.T) []marshalTest {
 	}
 
 	{
-		msg, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-		if err != nil {
-			t.Fatal(err)
-		}
+		msg, seg := capnp.NewSingleSegmentMessage(nil)
 		holder, err := air.NewRootRWTestCapn(seg)
 		if err != nil {
 			t.Fatal(err)
@@ -815,10 +755,7 @@ var bitListTests = []bitListTest{
 }
 
 func (blt bitListTest) makeMessage() (*capnp.Message, error) {
-	msg, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		return nil, err
-	}
+	msg, seg := capnp.NewSingleSegmentMessage(nil)
 	z, err := air.NewRootZ(seg)
 	if err != nil {
 		return nil, err
@@ -1108,10 +1045,7 @@ func TestDataVersioningAvoidsUnnecessaryTruncation(t *testing.T) {
 	}
 
 	// Store the larger message into another segment.
-	freshMsg, freshSeg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		t.Fatal("NewMessage:", err)
-	}
+	freshMsg, freshSeg := capnp.NewSingleSegmentMessage(nil)
 	wrapEmpty, err := air.NewRootWrapEmpty(freshSeg)
 	if err != nil {
 		t.Fatal("NewRootWrapEmpty:", err)
@@ -1193,10 +1127,7 @@ func TestEnumFromString(t *testing.T) {
 
 func TestDefaultStructField(t *testing.T) {
 	t.Parallel()
-	_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		t.Fatal(err)
-	}
+	_, seg := capnp.NewSingleSegmentMessage(nil)
 	root, err := air.NewRootStackingRoot(seg)
 	if err != nil {
 		t.Fatal(err)
@@ -1214,18 +1145,12 @@ func TestDefaultStructField(t *testing.T) {
 
 func TestDataTextCopyOptimization(t *testing.T) {
 	t.Parallel()
-	_, seg1, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		t.Fatal(err)
-	}
+	_, seg1 := capnp.NewSingleSegmentMessage(nil)
 	root, err := air.NewRootNester1Capn(seg1)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, seg2, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		t.Fatal(err)
-	}
+	_, seg2 := capnp.NewSingleSegmentMessage(nil)
 	strsl, err := capnp.NewTextList(seg2, 256)
 	if err != nil {
 		t.Fatal(err)
@@ -1278,8 +1203,8 @@ func BenchmarkTextMovementBetweenSegments(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, seg, _ := capnp.NewMessage(capnp.SingleSegment(buf[:0]))
-		_, scratch, _ := capnp.NewMessage(capnp.SingleSegment(buf2[:0]))
+		_, seg := capnp.NewSingleSegmentMessage(buf[:0])
+		_, scratch := capnp.NewSingleSegmentMessage(buf2[:0])
 
 		ht, _ := air.NewRootHoldsText(seg)
 		// Purposefully created in another segment.
@@ -1606,10 +1531,7 @@ func TestVoidUnionSetters(t *testing.T) {
 		1, 0, 0, 0, 0, 0, 0, 0,
 	})
 
-	msg, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		t.Fatal(err)
-	}
+	msg, seg := capnp.NewSingleSegmentMessage(nil)
 	voidUnion, err := air.NewRootVoidUnion(seg)
 	if err != nil {
 		t.Fatal(err)
@@ -1738,10 +1660,7 @@ func BenchmarkMarshal(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a := data[r.Intn(len(data))]
-		msg, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-		if err != nil {
-			b.Fatal(err)
-		}
+		msg, seg := capnp.NewSingleSegmentMessage(nil)
 		root, err := air.NewRootBenchmarkA(seg)
 		if err != nil {
 			b.Fatal(err)
@@ -1762,10 +1681,7 @@ func BenchmarkMarshal_ReuseMsg(b *testing.B) {
 	for i := range data {
 		data[i] = generateA(r)
 	}
-	msg, _, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		b.Fatal(err)
-	}
+	msg, _ := capnp.NewSingleSegmentMessage(nil)
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -1798,7 +1714,7 @@ func BenchmarkUnmarshal(b *testing.B) {
 	data := make([]testCase, 1000)
 	for i := range data {
 		a := generateA(r)
-		msg, seg, _ := capnp.NewMessage(capnp.SingleSegment(nil))
+		msg, seg := capnp.NewSingleSegmentMessage(nil)
 		root, _ := air.NewRootBenchmarkA(seg)
 		a.fill(root)
 		buf, err := msg.Marshal()
@@ -1841,7 +1757,7 @@ func BenchmarkUnmarshal_Reuse(b *testing.B) {
 	data := make([]testCase, 1000)
 	for i := range data {
 		a := generateA(r)
-		msg, seg, _ := capnp.NewMessage(capnp.SingleSegment(nil))
+		msg, seg := capnp.NewSingleSegmentMessage(nil)
 		root, _ := air.NewRootBenchmarkA(seg)
 		a.fill(root)
 		buf, err := msg.Marshal()
@@ -1879,7 +1795,7 @@ func BenchmarkDecode(b *testing.B) {
 
 	for i := 0; i < count; i++ {
 		a := generateA(r)
-		msg, seg, _ := capnp.NewMessage(capnp.SingleSegment(nil))
+		msg, seg := capnp.NewSingleSegmentMessage(nil)
 		root, _ := air.NewRootBenchmarkA(seg)
 		a.fill(root)
 		enc.Encode(msg)
@@ -2038,10 +1954,7 @@ func TestPointerDepthDefenseAcrossStructsAndLists(t *testing.T) {
 
 func TestHasPointerInUnion(t *testing.T) {
 	t.Parallel()
-	_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		t.Fatal("NewMessage:", err)
-	}
+	_, seg := capnp.NewSingleSegmentMessage(nil)
 	craft, err := air.NewRootAircraft(seg)
 	if err != nil {
 		t.Fatal("NewRootAircraft:", err)
@@ -2063,10 +1976,7 @@ func TestHasPointerInUnion(t *testing.T) {
 
 func TestSetNilBlob(t *testing.T) {
 	t.Parallel()
-	_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		t.Fatal("NewMessage:", err)
-	}
+	_, seg := capnp.NewSingleSegmentMessage(nil)
 	z, err := air.NewRootZ(seg)
 	if err != nil {
 		t.Fatal("NewRootZ:", err)
@@ -2089,10 +1999,7 @@ func TestSetNilBlob(t *testing.T) {
 
 func TestSetEmptyText(t *testing.T) {
 	t.Parallel()
-	_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		t.Fatal("NewMessage:", err)
-	}
+	_, seg := capnp.NewSingleSegmentMessage(nil)
 	z, err := air.NewRootZ(seg)
 	if err != nil {
 		t.Fatal("NewRootZ:", err)
@@ -2122,10 +2029,7 @@ func TestSetEmptyText(t *testing.T) {
 
 func TestSetNilBlobWithDefault(t *testing.T) {
 	t.Parallel()
-	_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		t.Fatal("NewMessage:", err)
-	}
+	_, seg := capnp.NewSingleSegmentMessage(nil)
 	d, err := air.NewRootDefaults(seg)
 	if err != nil {
 		t.Fatal("NewRootDefaults:", err)
@@ -2149,10 +2053,7 @@ func TestSetNilBlobWithDefault(t *testing.T) {
 
 func TestSetEmptyTextWithDefault(t *testing.T) {
 	t.Parallel()
-	_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		t.Fatal("NewMessage:", err)
-	}
+	_, seg := capnp.NewSingleSegmentMessage(nil)
 	d, err := air.NewRootDefaults(seg)
 	if err != nil {
 		t.Fatal("NewRootDefaults:", err)

--- a/integrationutil_test.go
+++ b/integrationutil_test.go
@@ -28,10 +28,7 @@ func initNester(t *testing.T, n air.Nester1Capn, strs ...string) {
 }
 
 func zdateFilledMessage(t testing.TB, n int32) *capnp.Message {
-	msg, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		t.Fatal(err)
-	}
+	msg, seg := capnp.NewSingleSegmentMessage(nil)
 	z, err := air.NewRootZ(seg)
 	if err != nil {
 		t.Fatal(err)
@@ -56,10 +53,7 @@ func zdateFilledMessage(t testing.TB, n int32) *capnp.Message {
 }
 
 func zdataFilledMessage(t testing.TB, n int) *capnp.Message {
-	msg, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		t.Fatal(err)
-	}
+	msg, seg := capnp.NewSingleSegmentMessage(nil)
 	z, err := air.NewRootZ(seg)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/demo/book_test.go
+++ b/internal/demo/book_test.go
@@ -18,10 +18,7 @@ func Example_book() {
 
 func writer(out io.Writer) {
 	// Make a brand new empty message.  A Message allocates Cap'n Proto structs.
-	msg, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		panic(err)
-	}
+	msg, seg := capnp.NewSingleSegmentMessage(nil)
 
 	// Create a new Book struct.  Every message must have a root struct.
 	book, err := books.NewRootBook(seg)

--- a/internal/fuzztest/fuzztest.go
+++ b/internal/fuzztest/fuzztest.go
@@ -21,7 +21,7 @@ func Fuzz(data []byte) int {
 			data = append(data, 0)
 		}
 	}
-	msg := &capnp.Message{Arena: capnp.SingleSegment(data)}
+	msg, _ := capnp.NewSingleSegmentMessage(data)
 	z, err := air.ReadRootZ(msg)
 	if err != nil {
 		return 0

--- a/list_test.go
+++ b/list_test.go
@@ -8,14 +8,10 @@ import (
 )
 
 func TestToListDefault(t *testing.T) {
-	msg := &Message{Arena: SingleSegment([]byte{
+	_, seg := NewSingleSegmentMessage([]byte{
 		0, 0, 0, 0, 0, 0, 0, 0,
 		42, 0, 0, 0, 0, 0, 0, 0,
-	})}
-	seg, err := msg.Segment(0)
-	if err != nil {
-		t.Fatal(err)
-	}
+	})
 	tests := []struct {
 		ptr  Ptr
 		def  []byte
@@ -56,15 +52,11 @@ func TestToListDefault(t *testing.T) {
 }
 
 func TestTextListBytesAt(t *testing.T) {
-	msg := &Message{Arena: SingleSegment([]byte{
+	_, seg := NewSingleSegmentMessage([]byte{
 		0, 0, 0, 0, 0, 0, 0, 0,
 		0x01, 0, 0, 0, 0x22, 0, 0, 0,
 		'f', 'o', 'o', 0, 0, 0, 0, 0,
-	})}
-	seg, err := msg.Segment(0)
-	if err != nil {
-		t.Fatal(err)
-	}
+	})
 	list := TextList{
 		seg:        seg,
 		off:        8,

--- a/list_test.go
+++ b/list_test.go
@@ -82,10 +82,7 @@ func TestTextListBytesAt(t *testing.T) {
 }
 
 func TestListRaw(t *testing.T) {
-	_, seg, err := NewMessage(SingleSegment(nil))
-	if err != nil {
-		t.Fatal(err)
-	}
+	_, seg := NewSingleSegmentMessage(nil)
 	tests := []struct {
 		list List
 		raw  rawPointer
@@ -136,8 +133,7 @@ func TestListRaw(t *testing.T) {
 // list, the pointer would be read out of the data section of the relevant
 // element, rather than the pointer section.
 func TestListCastRegression(t *testing.T) {
-	_, seg, err := NewMessage(SingleSegment(nil))
-	assert.Nil(t, err)
+	_, seg := NewSingleSegmentMessage(nil)
 
 	txt, err := NewText(seg, "Text")
 	assert.Nil(t, err)

--- a/message_test.go
+++ b/message_test.go
@@ -70,31 +70,13 @@ func TestAlloc(t *testing.T) {
 	var tests []allocTest
 
 	{
-		msg := &Message{Arena: SingleSegment(nil)}
-		seg, err := msg.Segment(0)
-		if err != nil {
-			t.Fatal(err)
-		}
+		_, seg := NewSingleSegmentMessage(nil)
 		tests = append(tests, allocTest{
 			name:    "empty alloc in empty segment",
 			seg:     seg,
 			size:    0,
 			allocID: 0,
-			addr:    0,
-		})
-	}
-	{
-		msg := &Message{Arena: SingleSegment(nil)}
-		seg, err := msg.Segment(0)
-		if err != nil {
-			t.Fatal(err)
-		}
-		tests = append(tests, allocTest{
-			name:    "alloc in empty segment",
-			seg:     seg,
-			size:    8,
-			allocID: 0,
-			addr:    0,
+			addr:    8, // First alloc is after root pointer.
 		})
 	}
 	{
@@ -400,7 +382,7 @@ func TestAddCap(t *testing.T) {
 	hook2 := new(dummyHook)
 	client1 := NewClient(hook1)
 	client2 := NewClient(hook2)
-	msg := &Message{Arena: SingleSegment(nil)}
+	msg, _ := NewSingleSegmentMessage(nil)
 
 	// Simple case: distinct non-nil clients.
 	id1 := msg.CapTable().Add(client1.AddRef())
@@ -454,10 +436,7 @@ func TestAddCap(t *testing.T) {
 func TestFirstSegmentMessage_SingleSegment(t *testing.T) {
 	t.Parallel()
 
-	msg, seg, err := NewMessage(SingleSegment(nil))
-	if err != nil {
-		t.Fatal(err)
-	}
+	msg, seg := NewSingleSegmentMessage(nil)
 	if msg.NumSegments() != 1 {
 		t.Errorf("msg.NumSegments() = %d; want 1", msg.NumSegments())
 	}
@@ -477,10 +456,7 @@ func TestFirstSegmentMessage_SingleSegment(t *testing.T) {
 func TestFirstSegmentMessage_MultiSegment(t *testing.T) {
 	t.Parallel()
 
-	msg, seg, err := NewMessage(MultiSegment(nil))
-	if err != nil {
-		t.Fatal(err)
-	}
+	msg, seg := NewMultiSegmentMessage(nil)
 	if msg.NumSegments() != 1 {
 		t.Errorf("msg.NumSegments() = %d; want 1", msg.NumSegments())
 	}

--- a/pogs/bench_test.go
+++ b/pogs/bench_test.go
@@ -34,7 +34,7 @@ func BenchmarkExtract(b *testing.B) {
 	data := make([][]byte, 1000)
 	for i := range data {
 		a := generateA(r)
-		msg, seg, _ := capnp.NewMessage(capnp.SingleSegment(nil))
+		msg, seg := capnp.NewSingleSegmentMessage(nil)
 		root, _ := air.NewRootBenchmarkA(seg)
 		Insert(air.BenchmarkA_TypeID, capnp.Struct(root), a)
 		data[i], _ = msg.Marshal()
@@ -60,7 +60,7 @@ func BenchmarkInsert(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		a := data[r.Intn(len(data))]
-		msg, seg, _ := capnp.NewMessage(capnp.SingleSegment(arena[:0]))
+		msg, seg := capnp.NewSingleSegmentMessage(arena[:0])
 		root, _ := air.NewRootBenchmarkA(seg)
 		Insert(air.BenchmarkA_TypeID, capnp.Struct(root), a)
 		msg.Marshal()

--- a/pogs/doc.go
+++ b/pogs/doc.go
@@ -25,7 +25,7 @@ and the Go struct:
 
 We can copy the Go struct into a Cap'n Proto struct like this:
 
-	_, arena, _ := capnp.NewMessage(capnp.SingleSegment(nil))
+	_, arena := capnp.NewSingleSegmentMessage(nil)
 	root, _ := myschema.NewRootMessage(arena)
 	m := &Message{"Alice", "Hello", 1294706395881547000}
 	err := pogs.Insert(myschema.Message_TypeID, root.Struct, m)

--- a/pogs/embed_test.go
+++ b/pogs/embed_test.go
@@ -31,10 +31,7 @@ type F16 struct {
 }
 
 func TestExtract_Embed(t *testing.T) {
-	_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		t.Fatalf("NewMessage: %v", err)
-	}
+	_, seg := capnp.NewSingleSegmentMessage(nil)
 	v1, err := air.NewRootVerOneData(seg)
 	if err != nil {
 		t.Fatalf("NewRootVerOneData: %v", err)
@@ -50,10 +47,7 @@ func TestExtract_Embed(t *testing.T) {
 }
 
 func TestExtract_EmbedPtr(t *testing.T) {
-	_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		t.Fatalf("NewMessage: %v", err)
-	}
+	_, seg := capnp.NewSingleSegmentMessage(nil)
 	v2, err := air.NewRootVerTwoData(seg)
 	if err != nil {
 		t.Fatalf("NewRootVerTwoData: %v", err)
@@ -70,10 +64,7 @@ func TestExtract_EmbedPtr(t *testing.T) {
 }
 
 func TestExtract_EmbedOmit(t *testing.T) {
-	_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		t.Fatalf("NewMessage: %v", err)
-	}
+	_, seg := capnp.NewSingleSegmentMessage(nil)
 	v2, err := air.NewRootVerTwoData(seg)
 	if err != nil {
 		t.Fatalf("NewRootVerTwoData: %v", err)
@@ -90,10 +81,7 @@ func TestExtract_EmbedOmit(t *testing.T) {
 }
 
 func TestExtract_EmbedName(t *testing.T) {
-	_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		t.Fatalf("NewMessage: %v", err)
-	}
+	_, seg := capnp.NewSingleSegmentMessage(nil)
 	f16, err := air.NewRootF16(seg)
 	if err != nil {
 		t.Fatalf("NewRootF16: %v", err)
@@ -118,10 +106,7 @@ func TestExtract_EmbedName(t *testing.T) {
 }
 
 func TestInsert_Embed(t *testing.T) {
-	_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		t.Fatalf("NewMessage: %v", err)
-	}
+	_, seg := capnp.NewSingleSegmentMessage(nil)
 	v1, err := air.NewRootVerOneData(seg)
 	if err != nil {
 		t.Fatalf("NewRootVerOneData: %v", err)
@@ -137,10 +122,7 @@ func TestInsert_Embed(t *testing.T) {
 }
 
 func TestInsert_EmbedPtr(t *testing.T) {
-	_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		t.Fatalf("NewMessage: %v", err)
-	}
+	_, seg := capnp.NewSingleSegmentMessage(nil)
 	v2, err := air.NewRootVerTwoData(seg)
 	if err != nil {
 		t.Fatalf("NewRootVerTwoData: %v", err)
@@ -156,10 +138,7 @@ func TestInsert_EmbedPtr(t *testing.T) {
 }
 
 func TestInsert_EmbedNilPtr(t *testing.T) {
-	_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		t.Fatalf("NewMessage: %v", err)
-	}
+	_, seg := capnp.NewSingleSegmentMessage(nil)
 	v2, err := air.NewRootVerTwoData(seg)
 	if err != nil {
 		t.Fatalf("NewRootVerTwoData: %v", err)
@@ -175,10 +154,7 @@ func TestInsert_EmbedNilPtr(t *testing.T) {
 }
 
 func TestInsert_EmbedOmit(t *testing.T) {
-	_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		t.Fatalf("NewMessage: %v", err)
-	}
+	_, seg := capnp.NewSingleSegmentMessage(nil)
 	v2, err := air.NewRootVerTwoData(seg)
 	if err != nil {
 		t.Fatalf("NewRootVerTwoData: %v", err)
@@ -194,10 +170,7 @@ func TestInsert_EmbedOmit(t *testing.T) {
 }
 
 func TestInsert_EmbedNamed(t *testing.T) {
-	_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		t.Fatalf("NewMessage: %v", err)
-	}
+	_, seg := capnp.NewSingleSegmentMessage(nil)
 	f16, err := air.NewRootF16(seg)
 	if err != nil {
 		t.Fatalf("NewRootF16: %v", err)
@@ -280,10 +253,7 @@ type VerOneData3Tags struct {
 }
 
 func TestExtract_EmbedCollide(t *testing.T) {
-	_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		t.Fatalf("NewMessage: %v", err)
-	}
+	_, seg := capnp.NewSingleSegmentMessage(nil)
 	v1, err := air.NewRootVerOneData(seg)
 	if err != nil {
 		t.Fatalf("NewRootVerOneData: %v", err)
@@ -344,11 +314,7 @@ func TestInsert_EmbedCollide(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-		if err != nil {
-			t.Errorf("%s: NewMessage: %v", test.name, err)
-			continue
-		}
+		_, seg := capnp.NewSingleSegmentMessage(nil)
 		v1, err := air.NewRootVerOneData(seg)
 		if err != nil {
 			t.Errorf("%s: NewRootVerOneData: %v", test.name, err)

--- a/pogs/example_test.go
+++ b/pogs/example_test.go
@@ -68,10 +68,7 @@ func ExampleInsert() {
 	}
 
 	// Allocate a new Cap'n Proto Book struct.
-	_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		panic(err)
-	}
+	_, seg := capnp.NewSingleSegmentMessage(nil)
 	root, err := books.NewRootBook(seg)
 	if err != nil {
 		panic(err)

--- a/pogs/pogs_test.go
+++ b/pogs/pogs_test.go
@@ -182,14 +182,14 @@ var goodTests = []Z{
 }
 
 func newTestStruct() capnp.Struct {
-	_, seg, _ := capnp.NewMessage(capnp.SingleSegment(nil))
+	_, seg := capnp.NewSingleSegmentMessage(nil)
 	s, _ := capnp.NewRootStruct(seg, capnp.ObjectSize{DataSize: 8})
 	s.SetUint32(0, 0xdeadbeef)
 	return s
 }
 
 func newTestList() capnp.List {
-	_, seg, _ := capnp.NewMessage(capnp.SingleSegment(nil))
+	_, seg := capnp.NewSingleSegmentMessage(nil)
 	l, _ := capnp.NewInt32List(seg, 3)
 	l.Set(0, 123)
 	l.Set(1, 456)
@@ -198,18 +198,14 @@ func newTestList() capnp.List {
 }
 
 func newTestInterface() capnp.Interface {
-	msg, seg, _ := capnp.NewMessage(capnp.SingleSegment(nil))
+	msg, seg := capnp.NewSingleSegmentMessage(nil)
 	id := msg.CapTable().Add(capnp.ErrorClient(errors.New("boo")))
 	return capnp.NewInterface(seg, id)
 }
 
 func TestExtract(t *testing.T) {
 	for _, test := range goodTests {
-		_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-		if err != nil {
-			t.Errorf("NewMessage for %s: %v", zpretty.Sprint(test), err)
-			continue
-		}
+		_, seg := capnp.NewSingleSegmentMessage(nil)
 		z, err := air.NewRootZ(seg)
 		if err != nil {
 			t.Errorf("NewRootZ for %s: %v", zpretty.Sprint(test), err)
@@ -231,11 +227,7 @@ func TestExtract(t *testing.T) {
 
 func TestInsert(t *testing.T) {
 	for _, test := range goodTests {
-		_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-		if err != nil {
-			t.Errorf("NewMessage for %s: %v", zpretty.Sprint(test), err)
-			continue
-		}
+		_, seg := capnp.NewSingleSegmentMessage(nil)
 		z, err := air.NewRootZ(seg)
 		if err != nil {
 			t.Errorf("NewRootZ for %s: %v", zpretty.Sprint(test), err)
@@ -464,11 +456,7 @@ func TestInsert_Size(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-		if err != nil {
-			t.Errorf("%s: NewMessage: %v", test.name, err)
-			continue
-		}
+		_, seg := capnp.NewSingleSegmentMessage(nil)
 		st, err := capnp.NewRootStruct(seg, test.sz)
 		if err != nil {
 			t.Errorf("%s: NewRootStruct(seg, %v): %v", test.name, test.sz, err)
@@ -491,10 +479,7 @@ type BytesZ struct {
 }
 
 func TestExtract_StringBytes(t *testing.T) {
-	_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		t.Fatalf("NewMessage: %v", err)
-	}
+	_, seg := capnp.NewSingleSegmentMessage(nil)
 	z, err := air.NewRootZ(seg)
 	if err != nil {
 		t.Fatalf("NewRootZ: %v", err)
@@ -514,10 +499,7 @@ func TestExtract_StringBytes(t *testing.T) {
 }
 
 func TestExtract_StringListBytes(t *testing.T) {
-	_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		t.Fatalf("NewMessage: %v", err)
-	}
+	_, seg := capnp.NewSingleSegmentMessage(nil)
 	z, err := air.NewRootZ(seg)
 	if err != nil {
 		t.Fatalf("NewRootZ: %v", err)
@@ -540,10 +522,7 @@ func TestExtract_StringListBytes(t *testing.T) {
 }
 
 func TestInsert_StringBytes(t *testing.T) {
-	_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		t.Fatalf("NewMessage: %v", err)
-	}
+	_, seg := capnp.NewSingleSegmentMessage(nil)
 	z, err := air.NewRootZ(seg)
 	if err != nil {
 		t.Fatalf("NewRootZ: %v", err)
@@ -562,10 +541,7 @@ func TestInsert_StringBytes(t *testing.T) {
 }
 
 func TestInsert_StringListBytes(t *testing.T) {
-	_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		t.Fatalf("NewMessage: %v", err)
-	}
+	_, seg := capnp.NewSingleSegmentMessage(nil)
 	z, err := air.NewRootZ(seg)
 	if err != nil {
 		t.Fatalf("NewRootZ: %v", err)
@@ -610,10 +586,7 @@ func (z *StructZ) equal(y *StructZ) bool {
 }
 
 func TestExtract_StructNoPtr(t *testing.T) {
-	_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		t.Fatalf("NewMessage: %v", err)
-	}
+	_, seg := capnp.NewSingleSegmentMessage(nil)
 	z, err := air.NewRootZ(seg)
 	if err != nil {
 		t.Fatalf("NewRootZ: %v", err)
@@ -633,10 +606,7 @@ func TestExtract_StructNoPtr(t *testing.T) {
 }
 
 func TestExtract_StructListNoPtr(t *testing.T) {
-	_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		t.Fatalf("NewMessage: %v", err)
-	}
+	_, seg := capnp.NewSingleSegmentMessage(nil)
 	z, err := air.NewRootZ(seg)
 	if err != nil {
 		t.Fatalf("NewRootZ: %v", err)
@@ -660,10 +630,7 @@ func TestExtract_StructListNoPtr(t *testing.T) {
 }
 
 func TestExtract_GroupNoPtr(t *testing.T) {
-	_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		t.Fatalf("NewMessage: %v", err)
-	}
+	_, seg := capnp.NewSingleSegmentMessage(nil)
 	z, err := air.NewRootZ(seg)
 	if err != nil {
 		t.Fatalf("NewRootZ: %v", err)
@@ -683,10 +650,7 @@ func TestExtract_GroupNoPtr(t *testing.T) {
 }
 
 func TestInsert_StructNoPtr(t *testing.T) {
-	_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		t.Fatalf("NewMessage: %v", err)
-	}
+	_, seg := capnp.NewSingleSegmentMessage(nil)
 	z, err := air.NewRootZ(seg)
 	if err != nil {
 		t.Fatalf("NewRootZ: %v", err)
@@ -705,10 +669,7 @@ func TestInsert_StructNoPtr(t *testing.T) {
 }
 
 func TestInsert_StructListNoPtr(t *testing.T) {
-	_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		t.Fatalf("NewMessage: %v", err)
-	}
+	_, seg := capnp.NewSingleSegmentMessage(nil)
 	z, err := air.NewRootZ(seg)
 	if err != nil {
 		t.Fatalf("NewRootZ: %v", err)
@@ -731,10 +692,7 @@ func TestInsert_StructListNoPtr(t *testing.T) {
 }
 
 func TestInsert_GroupNoPtr(t *testing.T) {
-	_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		t.Fatalf("NewMessage: %v", err)
-	}
+	_, seg := capnp.NewSingleSegmentMessage(nil)
 	z, err := air.NewRootZ(seg)
 	if err != nil {
 		t.Fatalf("NewRootZ: %v", err)
@@ -783,11 +741,7 @@ func TestExtract_Tags(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-		if err != nil {
-			t.Errorf("%s: NewMessage: %v", test.name, err)
-			continue
-		}
+		_, seg := capnp.NewSingleSegmentMessage(nil)
 		z, err := air.NewRootZ(seg)
 		if err != nil {
 			t.Errorf("%s: NewRootZ: %v", test.name, err)
@@ -830,11 +784,7 @@ func TestInsert_Tags(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-		if err != nil {
-			t.Errorf("%s: NewMessage: %v", test.name, err)
-			continue
-		}
+		_, seg := capnp.NewSingleSegmentMessage(nil)
 		z, err := air.NewRootZ(seg)
 		if err != nil {
 			t.Errorf("%s: NewRootZ: %v", test.name, err)
@@ -857,10 +807,7 @@ type ZBool struct {
 }
 
 func TestExtract_FixedUnion(t *testing.T) {
-	_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		t.Fatalf("NewMessage: %v", err)
-	}
+	_, seg := capnp.NewSingleSegmentMessage(nil)
 	z, err := air.NewRootZ(seg)
 	if err != nil {
 		t.Fatalf("NewRootZ: %v", err)
@@ -878,10 +825,7 @@ func TestExtract_FixedUnion(t *testing.T) {
 }
 
 func TestExtract_FixedUnionMismatch(t *testing.T) {
-	_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		t.Fatalf("NewMessage: %v", err)
-	}
+	_, seg := capnp.NewSingleSegmentMessage(nil)
 	z, err := air.NewRootZ(seg)
 	if err != nil {
 		t.Fatalf("NewRootZ: %v", err)
@@ -896,10 +840,7 @@ func TestExtract_FixedUnionMismatch(t *testing.T) {
 }
 
 func TestInsert_FixedUnion(t *testing.T) {
-	_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		t.Fatalf("NewMessage: %v", err)
-	}
+	_, seg := capnp.NewSingleSegmentMessage(nil)
 	z, err := air.NewRootZ(seg)
 	if err != nil {
 		t.Fatalf("NewRootZ: %v", err)
@@ -923,10 +864,7 @@ type ZBoolU8 struct {
 }
 
 func TestMissingWhich(t *testing.T) {
-	_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		t.Fatalf("NewMessage: %v", err)
-	}
+	_, seg := capnp.NewSingleSegmentMessage(nil)
 	z, err := air.NewRootZ(seg)
 	if err != nil {
 		t.Fatalf("NewRootZ: %v", err)
@@ -951,10 +889,7 @@ type ZDateWithExtra struct {
 }
 
 func TestExtraFields(t *testing.T) {
-	_, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
-	if err != nil {
-		t.Fatalf("NewMessage: %v", err)
-	}
+	_, seg := capnp.NewSingleSegmentMessage(nil)
 	z, err := air.NewRootZdate(seg)
 	if err != nil {
 		t.Fatalf("NewRootZdate: %v", err)
@@ -981,7 +916,7 @@ func zequal(g *Z, c air.Z) (bool, error) {
 	if g.Which != c.Which() {
 		return false, nil
 	}
-	_, seg, _ := capnp.NewMessage(capnp.SingleSegment(nil))
+	_, seg := capnp.NewSingleSegmentMessage(nil)
 	d, _ := air.NewRootZ(seg)
 	if err := zfill(d, g); err != nil {
 		return false, err
@@ -993,7 +928,7 @@ func (z *Z) equal(y *Z) bool {
 	if z.Which != y.Which {
 		return false
 	}
-	_, seg, _ := capnp.NewMessage(capnp.SingleSegment(nil))
+	_, seg := capnp.NewSingleSegmentMessage(nil)
 	c, _ := air.NewZ(seg)
 	if err := zfill(c, z); err != nil {
 		return false

--- a/pointer_test.go
+++ b/pointer_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestEqual(t *testing.T) {
-	msg, seg, _ := NewMessage(SingleSegment(nil))
+	msg, seg := NewSingleSegmentMessage(nil)
 	emptyStruct1, _ := NewStruct(seg, ObjectSize{})
 	emptyStruct2, _ := NewStruct(seg, ObjectSize{})
 	zeroStruct1, _ := NewStruct(seg, ObjectSize{DataSize: 8, PointerCount: 1})

--- a/rpc/senderpromise_test.go
+++ b/rpc/senderpromise_test.go
@@ -644,7 +644,7 @@ func TestShortensPathAfterResolve(t *testing.T) {
 	t.Cleanup(func() { time.Sleep(100 * time.Millisecond) }) // Avoid log error after fail
 
 	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
+	ctx, cancel := context.WithTimeout(ctx, time.Second*120)
 	defer cancel()
 
 	// Promise that will be the bootstrap capability in C1 and will be

--- a/rpc/transport/transport.go
+++ b/rpc/transport/transport.go
@@ -124,12 +124,7 @@ func NewPackedStream(rwc io.ReadWriteCloser) Transport {
 //
 // It is safe to call NewMessage concurrently with RecvMessage.
 func (s *transport) NewMessage() (OutgoingMessage, error) {
-	arena := capnp.MultiSegment(nil)
-	_, seg, err := capnp.NewMessage(arena)
-	if err != nil {
-		err = transporterr.Annotate(exc.WrapError("new message", err), "stream transport")
-		return nil, err
-	}
+	_, seg := capnp.NewMultiSegmentMessage(nil)
 	m, err := rpccp.NewRootMessage(seg)
 	if err != nil {
 		err = transporterr.Annotate(exc.WrapError("new message", err), "stream transport")

--- a/segment_test.go
+++ b/segment_test.go
@@ -432,10 +432,7 @@ func TestSegmentWriteUint64(t *testing.T) {
 }
 
 func TestSetPtrCopyListMember(t *testing.T) {
-	_, seg, err := NewMessage(SingleSegment(nil))
-	if err != nil {
-		t.Fatal("NewMessage:", err)
-	}
+	_, seg := NewSingleSegmentMessage(nil)
 	root, err := NewRootStruct(seg, ObjectSize{PointerCount: 2})
 	if err != nil {
 		t.Fatal("NewRootStruct:", err)
@@ -489,10 +486,7 @@ func TestSetPtrCopyListMember(t *testing.T) {
 }
 
 func TestSetPtrToZeroSizeStruct(t *testing.T) {
-	_, seg, err := NewMessage(SingleSegment(nil))
-	if err != nil {
-		t.Fatal("NewMessage:", err)
-	}
+	_, seg := NewSingleSegmentMessage(nil)
 	root, err := NewRootStruct(seg, ObjectSize{PointerCount: 1})
 	if err != nil {
 		t.Fatal("NewRootStruct:", err)
@@ -731,10 +725,7 @@ func TestWriteDoubleFarPointer(t *testing.T) {
 
 func TestSetInterfacePtr(t *testing.T) {
 	t.Run("SameMessage", func(t *testing.T) {
-		msg, seg, err := NewMessage(SingleSegment(nil))
-		if err != nil {
-			t.Fatal("NewMessage:", err)
-		}
+		msg, seg := NewSingleSegmentMessage(nil)
 		msg.CapTable().Add(Client{}) // just to make the capability ID below non-zero
 		root, err := NewRootStruct(seg, ObjectSize{PointerCount: 2})
 		if err != nil {
@@ -780,15 +771,8 @@ func TestSetInterfacePtr(t *testing.T) {
 		}
 	})
 	t.Run("DifferentMessages", func(t *testing.T) {
-		msg1 := &Message{Arena: SingleSegment(nil)}
-		seg1, err := msg1.Segment(0)
-		if err != nil {
-			t.Fatal("msg1.Segment(0):", err)
-		}
-		msg2, seg2, err := NewMessage(SingleSegment(nil))
-		if err != nil {
-			t.Fatal("NewMessage:", err)
-		}
+		msg1, seg1 := NewSingleSegmentMessage(nil)
+		msg2, seg2 := NewSingleSegmentMessage(nil)
 		root, err := NewRootStruct(seg2, ObjectSize{PointerCount: 1})
 		if err != nil {
 			t.Fatal("NewRootStruct:", err)

--- a/segment_test.go
+++ b/segment_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"capnproto.org/go/capnp/v3/exp/bufferpool"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSegmentInBounds(t *testing.T) {
@@ -506,68 +507,65 @@ func TestSetPtrToZeroSizeStruct(t *testing.T) {
 }
 
 func TestReadFarPointers(t *testing.T) {
-	msg := &Message{
-		// an rpc.capnp Message
-		Arena: MultiSegment([][]byte{
-			// Segment 0
-			{
-				// Double-far pointer: segment 2, offset 0
-				0x06, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
-			},
-			// Segment 1
-			{
-				// (Root) Struct data section
-				0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-				// Struct pointer section
-				// Double-far pointer: segment 4, offset 0
-				0x06, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00,
-			},
-			// Segment 2
-			{
-				// Far pointer landing pad: segment 1, offset 0
-				0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
-				// Far pointer landing pad tag word: struct with 1 word data and 1 pointer
-				0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00,
-			},
-			// Segment 3
-			{
-				// (Root>0) Struct data section
-				0x00, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00,
-				0xaa, 0x70, 0x65, 0x21, 0xd7, 0x7b, 0x31, 0xa7,
-				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-				// Struct pointer section
-				// Far pointer: segment 4, offset 4
-				0x22, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00,
-				// Far pointer: segment 4, offset 7
-				0x3a, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00,
-				// Null
-				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-			},
-			// Segment 4
-			{
-				// Far pointer landing pad: segment 3, offset 0
-				0x02, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00,
-				// Far pointer landing pad tag word: struct with 3 word data and 3 pointer
-				0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x03, 0x00,
-				// (Root>0>0) Struct data section
-				0x54, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-				// Struct pointer section
-				// Null
-				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-				// Far pointer landing pad: struct pointer: offset -3, 1 word data, 1 pointer
-				0xf4, 0xff, 0xff, 0xff, 0x01, 0x00, 0x01, 0x00,
-				// (Root>0>1) Struct pointer section
-				// Struct pointer: offset 2, 1 word data
-				0x08, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
-				// Null
-				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-				// Far pointer landing pad: struct pointer: offset -3, 2 pointers
-				0xf4, 0xff, 0xff, 0xff, 0x00, 0x00, 0x02, 0x00,
-				// (Root>0>1>0) Struct data section
-				0x2a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-			},
-		}),
-	}
+	msg, _ := NewMultiSegmentMessage([][]byte{
+		// Segment 0
+		{
+			// Double-far pointer: segment 2, offset 0
+			0x06, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
+		},
+		// Segment 1
+		{
+			// (Root) Struct data section
+			0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			// Struct pointer section
+			// Double-far pointer: segment 4, offset 0
+			0x06, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00,
+		},
+		// Segment 2
+		{
+			// Far pointer landing pad: segment 1, offset 0
+			0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+			// Far pointer landing pad tag word: struct with 1 word data and 1 pointer
+			0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00,
+		},
+		// Segment 3
+		{
+			// (Root>0) Struct data section
+			0x00, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00,
+			0xaa, 0x70, 0x65, 0x21, 0xd7, 0x7b, 0x31, 0xa7,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			// Struct pointer section
+			// Far pointer: segment 4, offset 4
+			0x22, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00,
+			// Far pointer: segment 4, offset 7
+			0x3a, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00,
+			// Null
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		},
+		// Segment 4
+		{
+			// Far pointer landing pad: segment 3, offset 0
+			0x02, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00,
+			// Far pointer landing pad tag word: struct with 3 word data and 3 pointer
+			0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x03, 0x00,
+			// (Root>0>0) Struct data section
+			0x54, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			// Struct pointer section
+			// Null
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			// Far pointer landing pad: struct pointer: offset -3, 1 word data, 1 pointer
+			0xf4, 0xff, 0xff, 0xff, 0x01, 0x00, 0x01, 0x00,
+			// (Root>0>1) Struct pointer section
+			// Struct pointer: offset 2, 1 word data
+			0x08, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+			// Null
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			// Far pointer landing pad: struct pointer: offset -3, 2 pointers
+			0xf4, 0xff, 0xff, 0xff, 0x00, 0x00, 0x02, 0x00,
+			// (Root>0>1>0) Struct data section
+			0x2a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		},
+	})
 	rootp, err := msg.Root()
 	if err != nil {
 		t.Error("Root:", err)
@@ -604,42 +602,25 @@ func TestReadFarPointers(t *testing.T) {
 func TestWriteFarPointer(t *testing.T) {
 	// TODO(someday): run same test with a two-word list
 
-	msg := &Message{
-		Arena: MultiSegment([][]byte{
-			make([]byte, 8),
-			make([]byte, 0, 24),
-		}),
-	}
+	msg, _ := NewMultiSegmentMessage([][]byte{
+		make([]byte, 8),
+		make([]byte, 0, 24),
+	})
 	seg1, err := msg.Segment(1)
-	if err != nil {
-		t.Fatal("msg.Segment(1):", err)
-	}
+	require.NoError(t, err)
 	s, err := NewStruct(seg1, ObjectSize{DataSize: 8, PointerCount: 1})
-	if err != nil {
-		t.Fatal("NewStruct(msg.Segment(1), ObjectSize{8, 1}):", err)
-	}
-	if s.Segment() != seg1 {
-		t.Fatalf("struct allocated in segment %d", s.Segment().ID())
-	}
-	if err := msg.SetRoot(s.ToPtr()); err != nil {
-		t.Error("msg.SetRoot(...):", err)
-	}
+	require.NoError(t, err)
+	require.Equal(t, s.Segment(), seg1)
+	err = msg.SetRoot(s.ToPtr())
+	require.NoError(t, err)
 	seg0, err := msg.Segment(0)
-	if err != nil {
-		t.Fatal("msg.Segment(0):", err)
-	}
+	require.NoError(t, err)
 
 	root := rawPointer(binary.LittleEndian.Uint64(seg0.Data()))
-	if root.pointerType() != farPointer {
-		t.Fatalf("root (%#016x) type = %v; want %v (farPointer)", root, root.pointerType(), farPointer)
-	}
-	if root.farSegment() != 1 {
-		t.Fatalf("root points to segment %d; want 1", root.farSegment())
-	}
+	require.Equal(t, farPointer, root.pointerType())
+	require.Equal(t, SegmentID(1), root.farSegment())
 	padAddr := root.farAddress()
-	if padAddr > address(len(seg1.Data())-8) {
-		t.Fatalf("root points to out of bounds address %v; size of segment is %d", padAddr, len(seg1.Data()))
-	}
+	require.LessOrEqual(t, padAddr, address(len(seg1.Data())-8))
 
 	pad := rawPointer(binary.LittleEndian.Uint64(seg1.Data()[padAddr:]))
 	if pad.pointerType() != structPointer {
@@ -656,12 +637,10 @@ func TestWriteFarPointer(t *testing.T) {
 func TestWriteDoubleFarPointer(t *testing.T) {
 	// TODO(someday): run same test with a two-word list
 
-	msg := &Message{
-		Arena: MultiSegment([][]byte{
-			make([]byte, 8),
-			make([]byte, 0, 16),
-		}),
-	}
+	msg, _ := NewMultiSegmentMessage([][]byte{
+		make([]byte, 8),
+		make([]byte, 0, 16),
+	})
 
 	// Make arena writable again.
 	msg.Arena.(*MultiSegmentArena).bp = &bufferpool.Default


### PR DESCRIPTION
This PR modifies `Reset()` (and consequently `NewMessage()`) so that it can be used to initialize messages for reading.

Before this PR, `Reset()` would enforce that space for the root pointer was allocated in the associated arena, which could not be done for read-only messages. This PR changes it so that space for the root pointer is only allocated when strictly necessary. 

In the future, this will allow protecting Message values from wrong usage by enforcing the use of NewMessage to initialize message objects (instead of use of zero valued messages).


> [!WARNING]  
> This is a breaking API change. `NewMessage()` would fail if the underlying arena could not allocate space, and if this PR is merged that will not be true anymore.


