### PR TITLE
Provide an option to specify base context for RPC connection

### DIFF
--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -91,7 +91,7 @@ type Conn struct {
 	baseContext  func() context.Context
 
 	// bgctx is a Context that is canceled when shutdown starts. Note
-	// that if baseContext is not provided. it's parent is context.Background(),
+	// that if baseContext is not provided, it's parent is context.Background(),
 	// so we can rely on this being the *only* time it will be canceled.
 	bgctx context.Context
 
@@ -204,7 +204,7 @@ type Options struct {
 	// set this.
 	Network Network
 
-	// BaseContext is an optional funcation that returns a base context
+	// BaseContext is an optional function that returns a base context
 	// for any incoming connection. If ommitted, the context.Background()
 	// will be used instead.
 	BaseContext func() context.Context

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -88,10 +88,11 @@ type Conn struct {
 	bootstrap    capnp.Client
 	er           errReporter
 	abortTimeout time.Duration
+	baseContext  func() context.Context
 
 	// bgctx is a Context that is canceled when shutdown starts. Note
-	// that it's parent is context.Background(), so we can rely on this
-	// being the *only* time it will be canceled.
+	// that if baseContext is not provided. it's parent is context.Background(),
+	// so we can rely on this being the *only* time it will be canceled.
 	bgctx context.Context
 
 	// tasks block shutdown.
@@ -202,6 +203,11 @@ type Options struct {
 	// by Dial or Accept on the Network itself; application code should not
 	// set this.
 	Network Network
+
+	// BaseContext is an optional funcation that returns a base context
+	// for any incoming connection. If ommitted, the context.Background()
+	// will be used instead.
+	BaseContext func() context.Context
 }
 
 // Logger is used for logging by the RPC system. Each method logs
@@ -231,8 +237,9 @@ type Logger interface {
 // requests from the transport.
 func NewConn(t Transport, opts *Options) *Conn {
 	c := &Conn{
-		transport: t,
-		closed:    make(chan struct{}),
+		transport:   t,
+		baseContext: context.Background,
+		closed:      make(chan struct{}),
 	}
 
 	sender := spsc.New[asyncSend]()
@@ -248,6 +255,10 @@ func NewConn(t Transport, opts *Options) *Conn {
 		c.abortTimeout = opts.AbortTimeout
 		c.network = opts.Network
 		c.remotePeerID = opts.RemotePeerID
+
+		if opts.BaseContext != nil {
+			c.baseContext = opts.BaseContext
+		}
 	}
 	if c.abortTimeout == 0 {
 		c.abortTimeout = 100 * time.Millisecond
@@ -261,7 +272,7 @@ func NewConn(t Transport, opts *Options) *Conn {
 func (c *Conn) startBackgroundTasks() {
 	// We use an errgroup to link the lifetime of background tasks
 	// to each other.
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(c.baseContext())
 	g, ctx := errgroup.WithContext(ctx)
 
 	c.bgctx = ctx


### PR DESCRIPTION
## Rationale

Providing a function to build base context is really useful in situations, when we need to propagate some, let's say, identity data to server handlers. Let's take the following issue as an example:
- "I need to pass the remote peer ID to my underlying handlers, so I could do some basic identification stuff"

The problem is that now the only way to do this is to set it in `rpc.Conn` and pass the connection to handlers, but this breaks abstraction between transport layer and application layer.
But we could do a simple change to have a context factory, so all the necessary connection information could be set in context, that will be passed to handlers later. And it's similar to how the native `http.Server` interface is [built](https://pkg.go.dev/net/http#Server).

## Real-life example (using libp2p as network stack):
```go
package handler

import 	(
       "capnproto.org/go/capnp/v3/rpc"
       "github.com/libp2p/go-libp2p/core"
)

type Handler struct {
    ...
}

func (h *Handler) Serve(stream core.Stream) *rpc.Conn {
        remotePeerID := stream.Conn().RemotePeer()

	conn := rpc.NewConn(rpc.NewPackedStreamTransport(stream), &rpc.Options{
		BootstrapClient: h.resolverHandler.Client(),
		BaseContext: func() context.Context {
		       return context.WithValue(context.Background(), "peerID", remotePeerID)
		},
	})

	return conn
}
```

