### PR TITLE
Fix failing tests and test network

### DIFF
--- a/rpc/level1_test.go
+++ b/rpc/level1_test.go
@@ -1053,5 +1053,5 @@ type rpcDisembargoContext struct {
 	Which            rpccp.Disembargo_context_Which
 	SenderLoopback   uint32
 	ReceiverLoopback uint32
-	Provide          uint32
+	Accept           capnp.Ptr
 }

--- a/schemas/schemas_test.go
+++ b/schemas/schemas_test.go
@@ -14,13 +14,13 @@ func TestDefaultFind(t *testing.T) {
 	if s := schemas.Find(0xdeadbeef); s != nil {
 		t.Errorf("schemas.Find(0xdeadbeef) = %d-byte slice; want nil", len(s))
 	}
-	s := schemas.Find(gocp.Package_)
+	s := schemas.Find(gocp.Package)
 	if s == nil {
-		t.Fatalf("schemas.Find(%#x) = nil", gocp.Package_)
+		t.Fatalf("schemas.Find(%#x) = nil", gocp.Package)
 	}
 	msg, err := capnp.Unmarshal(s)
 	if err != nil {
-		t.Fatalf("capnp.Unmarshal(schemas.Find(%#x)) error: %v", gocp.Package_, err)
+		t.Fatalf("capnp.Unmarshal(schemas.Find(%#x)) error: %v", gocp.Package, err)
 	}
 	req, err := schema.ReadRootCodeGeneratorRequest(msg)
 	if err != nil {
@@ -32,15 +32,15 @@ func TestDefaultFind(t *testing.T) {
 	}
 	for i := 0; i < nodes.Len(); i++ {
 		n := nodes.At(i)
-		if n.Id() == gocp.Package_ {
+		if n.Id() == gocp.Package {
 			// Found
 			if n.Which() != schema.Node_Which_annotation {
-				t.Errorf("found node %#x which = %v; want annotation", gocp.Package_, n.Which())
+				t.Errorf("found node %#x which = %v; want annotation", gocp.Package, n.Which())
 			}
 			return
 		}
 	}
-	t.Fatalf("could not find node %#x in registry", gocp.Package_)
+	t.Fatalf("could not find node %#x in registry", gocp.Package)
 }
 
 func TestNotFound(t *testing.T) {


### PR DESCRIPTION
This PR fixes some tests that failed due to the schema generator and the changed `Network` interface. This PR makes 2 changes to the (unused) testnetwork functionality:
- The `opts` field is now fixed for each vat in the test network.
  - This should be suitable for testing purposes, and it is expected that most applications are not changing their options per client.
  - There was also no way with the previous way to choose the options *knowing* the remote peer ID, meaning such a use case could not be simulated with the test network anyway.
- The incomplete 3PH functionality is removed.
  - This should be re-added to match the new interface for tests in the same PR as the first implementation of 3PH.