### PR TITLE
MultiSegmentArena: Fix release back into bufferpool

### DIFF
--- a/arena.go
+++ b/arena.go
@@ -267,6 +267,7 @@ func (msa *MultiSegmentArena) demux(hdr streamHeader, data []byte, bp *bufferpoo
 		msa.segs = append(msa.segs, make([]Segment, inc)...)
 	}
 
+	rawData := data
 	for i := SegmentID(0); i <= maxSeg; i++ {
 		sz, err := hdr.segmentSize(SegmentID(i))
 		if err != nil {
@@ -277,7 +278,7 @@ func (msa *MultiSegmentArena) demux(hdr streamHeader, data []byte, bp *bufferpoo
 		msa.segs[i].id = i
 	}
 
-	msa.rawData = data
+	msa.rawData = rawData
 	msa.bp = bp
 	return nil
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -1825,6 +1825,8 @@ func BenchmarkDecode(b *testing.B) {
 			if err != nil {
 				b.Fatal(err)
 			}
+
+			msg.Release()
 		}
 	}
 }


### PR DESCRIPTION
This fixes a bug that was preventing correct release of buffers allocated by Decode() back to the global buffer pool.

Previously, the data variable was overriden on the loop that splits the segments, preventing the correct tracking of the full data buffer and its subsequent return back to the buffer pool when the arena was released.

This also adds a .Release() call to the Decode benchmark to better reflect the ability to reuse buffers.