### PR TITLE
Add a test for all-zero stream decoding

### DIFF
--- a/message_test.go
+++ b/message_test.go
@@ -637,9 +637,7 @@ func (test_zero_stream) Read(b []byte) (int, error) {
 // See github.com/capnproto/go-capnp/issues/592
 func TestZeroStream(t *testing.T) {
 	m, err := NewDecoder(test_zero_stream{}).Decode()
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 
 	_, err = m.Root()
 	assert.NotNil(t, err, "expected error decoding zero stream")

--- a/message_test.go
+++ b/message_test.go
@@ -622,3 +622,25 @@ func TestCanResetArenaForRead(t *testing.T) {
 	_, err := msg.Reset(arena)
 	require.NoError(t, err)
 }
+
+type test_zero_stream struct{}
+
+func (test_zero_stream) Read(b []byte) (int, error) {
+	for i := 0; i < len(b); i++ {
+		b[i] = 0
+	}
+	return len(b), nil
+}
+
+// TestZeroStream checks that an all-zero stream will fail to decode with an
+// error, and not panic.
+// See github.com/capnproto/go-capnp/issues/592
+func TestZeroStream(t *testing.T) {
+	m, err := NewDecoder(test_zero_stream{}).Decode()
+	if err != nil {
+		panic(err)
+	}
+
+	_, err = m.Root()
+	assert.NotNil(t, err, "expected error decoding zero stream")
+}


### PR DESCRIPTION
Closes #592

The issue is already fixed on master by [this commit](https://github.com/capnproto/go-capnp/commit/25dbad995a4e761e4838ca224bb4f6c0191d5d41#diff-2ce052ca28a77c3b54be26bfc568dddef91bf239253d0ad537609af1731032d4R215). This only adds a test to prevent a future regression.