### PR TITLE
bufferpool: Improve performance

### DIFF
--- a/exp/bufferpool/pool.go
+++ b/exp/bufferpool/pool.go
@@ -2,7 +2,7 @@
 package bufferpool
 
 import (
-	"sync"
+	"math/bits"
 
 	"github.com/colega/zeropool"
 )
@@ -13,35 +13,21 @@ const (
 )
 
 // A default global pool.
-var Default Pool
+//
+// This pool defaults to bucketCount=20 and minAlloc=1024 (max size = ~1MiB).
+var Default Pool = *NewPool(defaultMinSize, defaultBucketCount)
 
-// Pool maintains a list of BucketCount buckets that contain buffers
-// of exponentially-increasing capacity, 1 << 0 to 1 << BucketCount.
+// Pool maintains a list of buffers, exponentially increasing in size. Values
+// MUST be initialized by NewPool().
 //
-// The MinAlloc field specifies the minimum capacity of new buffers
-// allocated by Pool, which improves reuse of small buffers. For the
-// avoidance of doubt:  calls to Get() with size < MinAlloc return a
-// buffer of len(buf) = size and cap(buf) >= MinAlloc. MinAlloc MUST
-// NOT exceed 1 << BucketCount, or method calls to Pool will panic.
-//
-// The zero-value Pool is ready to use, defaulting to BucketCount=20
-// and MinAlloc=1024 (max size = ~1MiB).  Most applications will not
-// benefit from tuning these parameters.
-//
-// As a general rule, increasing MinAlloc reduces GC latency at the
-// expense of increased memory usage.  Increasing BucketCount can
-// reduce GC latency in applications that frequently allocate large
-// buffers.
+// Buffer instances are safe for concurrent access.
 type Pool struct {
-	once                  sync.Once
-	MinAlloc, BucketCount int
-	buckets               bucketSlice
+	minAlloc int
+	buckets  bucketSlice
 }
 
 // Get a buffer of len(buf) == size and cap >= size.
 func (p *Pool) Get(size int) []byte {
-	p.init()
-
 	if buf := p.buckets.Get(size); buf != nil {
 		return buf[:size]
 	}
@@ -52,76 +38,122 @@ func (p *Pool) Get(size int) []byte {
 // Put returns the buffer to the pool.  The first len(buf) bytes
 // of the buffer are zeroed.
 func (p *Pool) Put(buf []byte) {
-	p.init()
-
 	for i := range buf {
 		buf[i] = 0
+	}
+
+	// Do not store buffers less than the min alloc size (prevents storing
+	// buffers that do not conform to the min alloc policy of this pool).
+	if cap(buf) < p.minAlloc {
+		return
 	}
 
 	p.buckets.Put(buf[:cap(buf)])
 }
 
-func (p *Pool) init() {
-	p.once.Do(func() {
-		if p.MinAlloc <= 0 {
-			p.MinAlloc = defaultMinSize
-		}
-
-		if p.BucketCount <= 0 {
-			p.BucketCount = defaultBucketCount
-		}
-
-		if p.MinAlloc > (1 << p.BucketCount) {
-			panic("MinAlloc greater than largest bucket")
-		}
-
-		// Get the index of the bucket responsible for MinAlloc.
-		var idx int
-		for idx = range p.buckets {
-			if 1<<idx >= p.MinAlloc {
-				break
-			}
-		}
-
-		p.buckets = make(bucketSlice, p.BucketCount)
-		for i := range p.buckets {
-			if i < idx {
-				// Set the 'New' function for all "small" buckets to
-				// n.buckets[idx].Get, so as to allow reuse of buffers
-				// smaller than MinAlloc that are passed to Put, while
-				// still maximizing reuse of buffers allocated by Get.
-				// Note that we cannot simply use n.buckets[idx].New,
-				// as this would side-step pooling.
-				p.buckets[i] = zeropool.New(p.buckets[idx].Get)
-			} else {
-				p.buckets[i] = zeropool.New(newAllocFunc(i))
-			}
-		}
-	})
-}
-
-type bucketSlice []zeropool.Pool[[]byte]
-
-func (bs bucketSlice) Get(size int) []byte {
-	for i := range bs {
-		if 1<<i >= size {
-			return bs[i].Get()
-		}
+// NewPool creates a list of BucketCount buckets that contain buffers
+// of exponentially-increasing capacity, 1 << 0 to 1 << BucketCount.
+//
+// The minAlloc field specifies the minimum capacity of new buffers
+// allocated by Pool, which improves reuse of small buffers. For the
+// avoidance of doubt:  calls to Get() with size < minAlloc return a
+// buffer of len(buf) = size and cap(buf) >= minAlloc. MinAlloc MUST
+// NOT exceed 1 << BucketCount, or method calls to Pool will panic.
+//
+// Passing zero to the parameters will default bucketCount to 20
+// and minAlloc to 1024 (max size = ~1MiB).
+//
+// As a general rule, increasing MinAlloc reduces GC latency at the
+// expense of increased memory usage.  Increasing BucketCount can
+// reduce GC latency in applications that frequently allocate large
+// buffers.
+func NewPool(minAlloc, bucketCount int) *Pool {
+	if minAlloc <= 0 {
+		minAlloc = defaultMinSize
 	}
 
+	if bucketCount <= 0 {
+		bucketCount = defaultBucketCount
+	}
+
+	if minAlloc > (1 << bucketCount) {
+		panic("MinAlloc greater than largest bucket")
+	}
+
+	if !isPowerOf2(minAlloc) {
+		panic("MinAlloc not a power of two")
+	}
+
+	return &Pool{
+		minAlloc: minAlloc,
+		buckets:  makeBucketSlice(minAlloc, bucketCount),
+	}
+}
+
+type bucketSlice []*zeropool.Pool[[]byte]
+
+func isPowerOf2(i int) bool {
+	return i&(i-1) == 0
+}
+
+func bucketToGet(size int) int {
+	i := bits.Len(uint(size))
+	if isPowerOf2(size) && size > 0 {
+		// When the size is a power of two, reduce by one (because
+		// bucket i is for sizes <= 1<< i).
+		i -= 1
+	}
+	return i
+}
+
+func bucketToPut(size int) int {
+	i := bits.Len(uint(size))
+
+	// Always put on the bucket whose upper bound is size == 1<<i.
+	i -= 1
+	return i
+}
+
+func (bs bucketSlice) Get(size int) []byte {
+	i := bucketToGet(size)
+	if i < len(bs) {
+		r := bs[i].Get()
+		return r
+	}
 	return nil
 }
 
 func (bs bucketSlice) Put(buf []byte) {
-	for i := range bs {
-		if cap(buf) >= 1<<i && cap(buf) < 1<<(i+1) {
-			bs[i].Put(buf)
-			break
-		}
+	i := bucketToPut(cap(buf))
+	if i < len(bs) {
+		bs[i].Put(buf)
 	}
 }
 
-func newAllocFunc(i int) func() []byte {
+// makeBucketSlice creates a new bucketSlice with the given parameters. These
+// are NOT validated.
+func makeBucketSlice(minAlloc, bucketCount int) bucketSlice {
+	// Create all buckets that are >= the bucket that stores the min
+	// allocation size.
+	minBucket := bucketToGet(minAlloc)
+	buckets := make(bucketSlice, bucketCount)
+	for i := minBucket; i < bucketCount; i++ {
+		bp := zeropool.New(newAllocFuncForBucket(i))
+		buckets[i] = &bp
+	}
+
+	// Buckets smaller than the min bucket size all get/put buffers in the
+	// minimum bucket size.
+	for i := 0; i < minBucket; i++ {
+		buckets[i] = buckets[minBucket]
+	}
+
+	return buckets
+}
+
+// newAllocFuncForBucket returns a function to allocate a byte slice of size
+// 2^i.
+func newAllocFuncForBucket(i int) func() []byte {
 	return func() []byte {
 		return make([]byte, 1<<i)
 	}

--- a/exp/bufferpool/pool_internal_test.go
+++ b/exp/bufferpool/pool_internal_test.go
@@ -1,0 +1,96 @@
+package bufferpool
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBucketIndex(t *testing.T) {
+	tests := []struct {
+		size int
+		get  int
+		put  int
+	}{
+		// Only sizes that are powers of two are obtained and returned
+		// to the same bucket.
+		//
+		// Sizes that are not a power of two must be fetched by the next
+		// higher power of two, but are returned to the lower one.
+		{size: 0, get: 0, put: -1},
+		{size: 1, get: 0, put: 0},
+		{size: 26, get: 5, put: 4}, // 26 == 0b00011010
+		{size: 32, get: 5, put: 5},
+		{size: 1024, get: 10, put: 10},
+		{size: 1025, get: 11, put: 10},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+		t.Run(fmt.Sprintf("%d", tc.size), func(t *testing.T) {
+			get := bucketToGet(tc.size)
+			require.Equal(t, tc.get, get)
+			put := bucketToPut(tc.size)
+			require.Equal(t, tc.put, put)
+		})
+	}
+}
+
+func TestBucketSlice(t *testing.T) {
+	const minAlloc = 8
+	const bucketCount = 10
+	const sizeLastBucket = 1 << (bucketCount - 1)
+
+	tests := []struct {
+		size    int
+		wantLen int
+		wantCap int
+	}{{
+		size:    -1, // Negative values are skipped.
+		wantLen: 0,
+		wantCap: 0,
+	}, {
+		size:    0,
+		wantLen: minAlloc,
+		wantCap: minAlloc,
+	}, {
+		size:    1,
+		wantLen: minAlloc,
+		wantCap: minAlloc,
+	}, {
+		size:    minAlloc,
+		wantLen: minAlloc,
+		wantCap: minAlloc,
+	}, {
+		size:    minAlloc + 1, // Goes to next bucket.
+		wantLen: minAlloc * 2,
+		wantCap: minAlloc * 2,
+	}, {
+		size:    minAlloc*2 + 1,
+		wantLen: minAlloc * 4,
+		wantCap: minAlloc * 4,
+	}, {
+		size:    sizeLastBucket - 1,
+		wantLen: sizeLastBucket,
+		wantCap: sizeLastBucket,
+	}, {
+		size:    sizeLastBucket,
+		wantLen: sizeLastBucket,
+		wantCap: sizeLastBucket,
+	}, {
+		size:    sizeLastBucket + 1, // Anything > last bucket size is not allocated.
+		wantLen: 0,
+		wantCap: 0,
+	}}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("%d", tc.size), func(t *testing.T) {
+			bs := makeBucketSlice(minAlloc, bucketCount)
+			require.Len(t, bs, bucketCount)
+			buf := bs.Get(tc.size)
+			require.Len(t, buf, tc.wantLen)
+			require.Equal(t, tc.wantCap, cap(buf))
+		})
+	}
+}

--- a/exp/bufferpool/pool_test.go
+++ b/exp/bufferpool/pool_test.go
@@ -10,13 +10,8 @@ import (
 func TestInvariants(t *testing.T) {
 	t.Parallel()
 
-	pool := bufferpool.Pool{
-		BucketCount: 1,
-		MinAlloc:    1024,
-	}
-
 	assert.Panics(t, func() {
-		pool.Get(32)
+		bufferpool.NewPool(1024, 1)
 	}, "should panic when BucketCount cannot satisfy MinAlloc.")
 }
 
@@ -24,38 +19,40 @@ func TestGet(t *testing.T) {
 	t.Parallel()
 	t.Helper()
 
-	pool := bufferpool.Pool{
-		BucketCount: 8,
-		MinAlloc:    64,
-	}
+	minAlloc, bucketCount := 64, 8
+	pool := bufferpool.NewPool(minAlloc, bucketCount)
 
 	t.Run("Size<MinAlloc", func(t *testing.T) {
-		assert.Len(t, pool.Get(32), 32, "should return buffer with len=32")
-		assert.Equal(t, 32, cap(pool.Get(32)), "should return buffer with cap=MinAlloc")
+		size := minAlloc / 2 // size < minAlloc
+		assert.Len(t, pool.Get(size), size, "should return buffer with len=%d", size)
+		assert.Equal(t, minAlloc, cap(pool.Get(size)), "should return buffer with cap=MinAlloc")
 	})
 
 	t.Run("Size=MinAlloc", func(t *testing.T) {
-		assert.Len(t, pool.Get(pool.MinAlloc), pool.MinAlloc, "should return buffer with len=MinAlloc")
-		assert.Equal(t, pool.MinAlloc, cap(pool.Get(pool.MinAlloc)), "should return buffer with cap=MinAlloc")
+		assert.Len(t, pool.Get(minAlloc), minAlloc, "should return buffer with len=MinAlloc")
+		assert.Equal(t, minAlloc, cap(pool.Get(minAlloc)), "should return buffer with cap=MinAlloc")
 	})
 
 	t.Run("Size>MinAlloc", func(t *testing.T) {
-		assert.Len(t, pool.Get(33), 33, "should return buffer with len=33")
-		assert.Equal(t, 128, cap(pool.Get(128)), "should return buffer with cap=128")
+		size := minAlloc + 1
+		nextAlloc := minAlloc << 1
+		assert.Len(t, pool.Get(size), size, "should return buffer with len=%d", size)
+		assert.Equal(t, nextAlloc, cap(pool.Get(size)), "should return buffer with cap=%d", nextAlloc)
 	})
 
 	t.Run("Size>MaxSize", func(t *testing.T) {
-		assert.Len(t, pool.Get(512), 512, "should return buffer with len=512")
-		assert.GreaterOrEqual(t, 512, cap(pool.Get(512)), "should return buffer with cap>=512")
+		size := 1<<(bucketCount+1) + 1
+		assert.Len(t, pool.Get(size), size, "should return buffer with len=%d", size)
+		assert.GreaterOrEqual(t, size, cap(pool.Get(size)), "should return buffer with cap>=%d", size)
 	})
 }
 
 func TestPut(t *testing.T) {
 	t.Parallel()
 
-	var pool bufferpool.Pool
+	pool := bufferpool.NewPool(1024, 20)
 
-	buf := make([]byte, 1024)
+	buf := make([]byte, 1024, 1024)
 	for i := range buf {
 		buf[i] = byte(i)
 	}
@@ -63,12 +60,15 @@ func TestPut(t *testing.T) {
 
 	pool.Put(buf)
 	buf = pool.Get(8)
+	fullBuf := buf[:cap(buf)]
 
+	assert.Len(t, fullBuf, 1024, "buf should have len and cap 1024")
 	assert.Equal(t, make([]byte, 8), buf, "should zero first 8 bytes")
+	assert.NotEqual(t, 0, fullBuf[9], "first byte after clearing should not be zero")
 }
 
 func BenchmarkPool(b *testing.B) {
-	var pool bufferpool.Pool
+	pool := bufferpool.NewPool(0, 0)
 	const size = 32
 
 	// Make cache hot.


### PR DESCRIPTION
This improves the performance of bufferpool by removing the mutex called on every operation (via init()) and improving bucket indexing by removing the loop and using direct index calculation.

Warning: this is a breaking API change. Zero valued Pool objects are no longer safe to be used and MUST be initialized by NewPool().

<details>
<summary>Benchmark results against current main branch</summary>

```
name                                        old time/op    new time/op    delta
MessageGetFirstSegment-6                      88.9ns ± 1%    51.5ns ± 2%  -42.04%  (p=0.000 n=10+10)
TextMovementBetweenSegments-6                  458µs ± 2%     457µs ± 1%     ~     (p=0.684 n=10+10)
Marshal-6                                     1.26µs ± 1%    1.21µs ± 1%   -4.35%  (p=0.000 n=10+10)
Marshal_ReuseMsg-6                             742ns ± 1%     682ns ± 1%   -8.12%  (p=0.000 n=9+10)
Unmarshal-6                                    890ns ± 1%     883ns ± 1%   -0.74%  (p=0.019 n=8+10)
Unmarshal_Reuse-6                              557ns ± 2%     562ns ± 2%     ~     (p=0.063 n=10+10)
Decode-6                                      4.91ms ± 1%    4.55ms ± 1%   -7.38%  (p=0.000 n=10+10)
Growth/SingleSegment/release=false-6          11.1ms ± 2%    11.2ms ± 2%   +0.97%  (p=0.019 n=10+10)
Growth/MultiSegment/release=false-6           11.9ms ± 1%    11.7ms ± 2%   -2.00%  (p=0.000 n=9+10)
Growth/SingleSegment/release=true-6           11.3ms ± 2%    11.3ms ± 1%     ~     (p=0.968 n=10+9)
Growth/MultiSegment/release=true-6            11.5ms ± 1%    11.5ms ± 2%     ~     (p=0.065 n=10+9)
SmallMessage/SingleSegment/release=false-6    1.15µs ± 2%    1.03µs ± 1%  -10.81%  (p=0.000 n=9+10)
SmallMessage/MultiSegment/release=false-6     1.22µs ± 1%    1.14µs ± 1%   -6.99%  (p=0.000 n=10+10)
SmallMessage/SingleSegment/release=true-6      721ns ± 1%     621ns ± 1%  -13.91%  (p=0.000 n=9+10)
SmallMessage/MultiSegment/release=true-6       667ns ± 1%     618ns ± 1%   -7.29%  (p=0.000 n=10+10)

name                                        old alloc/op   new alloc/op   delta
MessageGetFirstSegment-6                       0.00B          0.00B          ~     (all equal)
Marshal-6                                     1.32kB ± 0%    1.32kB ± 0%     ~     (p=0.294 n=10+8)
Marshal_ReuseMsg-6                             96.0B ± 0%     96.0B ± 0%     ~     (all equal)
Unmarshal-6                                     352B ± 0%      352B ± 0%     ~     (all equal)
Unmarshal_Reuse-6                              0.00B          0.00B          ~     (all equal)
Decode-6                                       801kB ± 0%     801kB ± 0%   +0.01%  (p=0.000 n=10+10)
Growth/SingleSegment/release=false-6          4.35MB ± 0%    4.35MB ± 0%     ~     (p=0.604 n=9+10)
Growth/MultiSegment/release=false-6           1.59MB ± 0%    1.59MB ± 0%     ~     (p=0.322 n=9+10)
Growth/SingleSegment/release=true-6           4.35MB ± 0%    4.35MB ± 0%     ~     (p=0.720 n=9+10)
Growth/MultiSegment/release=true-6             536kB ± 1%     536kB ± 0%     ~     (p=0.736 n=10+9)
SmallMessage/SingleSegment/release=false-6    1.22kB ± 0%    1.22kB ± 0%   +0.06%  (p=0.005 n=9+10)
SmallMessage/MultiSegment/release=false-6     1.43kB ± 0%    1.43kB ± 0%     ~     (p=0.248 n=10+9)
SmallMessage/SingleSegment/release=true-6      80.0B ± 0%     80.0B ± 0%     ~     (all equal)
SmallMessage/MultiSegment/release=true-6       80.0B ± 0%     80.0B ± 0%     ~     (all equal)

name                                        old allocs/op  new allocs/op  delta
MessageGetFirstSegment-6                        0.00           0.00          ~     (all equal)
Marshal-6                                       5.00 ± 0%      5.00 ± 0%     ~     (all equal)
Marshal_ReuseMsg-6                              1.00 ± 0%      1.00 ± 0%     ~     (all equal)
Unmarshal-6                                     3.00 ± 0%      3.00 ± 0%     ~     (all equal)
Unmarshal_Reuse-6                               0.00           0.00          ~     (all equal)
Decode-6                                       10.0k ± 0%     10.0k ± 0%     ~     (all equal)
Growth/SingleSegment/release=false-6            20.0 ± 0%      20.0 ± 0%     ~     (all equal)
Growth/MultiSegment/release=false-6             20.0 ± 0%      20.0 ± 0%     ~     (all equal)
Growth/SingleSegment/release=true-6             18.8 ± 4%      19.0 ± 0%     ~     (p=0.471 n=9+9)
Growth/MultiSegment/release=true-6              4.00 ± 0%      4.00 ± 0%     ~     (all equal)
SmallMessage/SingleSegment/release=false-6      4.00 ± 0%      4.00 ± 0%     ~     (all equal)
SmallMessage/MultiSegment/release=false-6       5.00 ± 0%      5.00 ± 0%     ~     (all equal)
SmallMessage/SingleSegment/release=true-6       1.00 ± 0%      1.00 ± 0%     ~     (all equal)
SmallMessage/MultiSegment/release=true-6        1.00 ± 0%      1.00 ± 0%     ~     (all equal)

name                                        old speed      new speed      delta
Decode-6                                     196MB/s ± 1%   211MB/s ± 1%   +7.97%  (p=0.000 n=10+10)
Growth/SingleSegment/release=false-6        94.3MB/s ± 2%  93.4MB/s ± 2%   -0.96%  (p=0.017 n=10+10)
Growth/MultiSegment/release=false-6         87.9MB/s ± 1%  89.6MB/s ± 2%   +2.04%  (p=0.000 n=9+10)
Growth/SingleSegment/release=true-6         92.7MB/s ± 2%  92.6MB/s ± 3%     ~     (p=0.754 n=10+10)
Growth/MultiSegment/release=true-6          91.5MB/s ± 1%  90.8MB/s ± 2%     ~     (p=0.063 n=10+9)
SmallMessage/SingleSegment/release=false-6  62.5MB/s ± 2%  70.0MB/s ± 1%  +12.10%  (p=0.000 n=9+10)
SmallMessage/MultiSegment/release=false-6   58.8MB/s ± 1%  63.3MB/s ± 1%   +7.51%  (p=0.000 n=10+10)
SmallMessage/SingleSegment/release=true-6    100MB/s ± 1%   116MB/s ± 1%  +16.15%  (p=0.000 n=9+10)
SmallMessage/MultiSegment/release=true-6     108MB/s ± 1%   116MB/s ± 1%   +7.87%  (p=0.000 n=10+10)
```

</details>
